### PR TITLE
fix: correct PYTHON_CONSTANTS source, np.pow, swallowed kwargs, debug hints

### DIFF
--- a/src/formulate/__init__.py
+++ b/src/formulate/__init__.py
@@ -3,7 +3,6 @@
 from __future__ import annotations
 
 import importlib.resources
-from typing import Any
 
 import lark
 
@@ -27,8 +26,8 @@ _numexpr_parser = _get_parser("numexpr")
 _root_parser = _get_parser("root")
 
 
-def from_root(exp: str, **kwargs: dict[str, Any]) -> AST.AST:
-    """Evaluate ROOT expressions."""
+def from_root(exp: str) -> AST.AST:
+    """Parse a ROOT expression and return an AST."""
     try:
         ptree = _root_parser.parse(exp)
     except lark.LarkError as e:
@@ -37,8 +36,8 @@ def from_root(exp: str, **kwargs: dict[str, Any]) -> AST.AST:
     return toast.toast(ptree)  # type: ignore[no-any-return]
 
 
-def from_numexpr(exp: str, **kwargs: dict[str, Any]) -> AST.AST:
-    """Evaluate numexpr expressions."""
+def from_numexpr(exp: str) -> AST.AST:
+    """Parse a numexpr expression and return an AST."""
     try:
         ptree = _numexpr_parser.parse(exp)
     except lark.LarkError as e:

--- a/src/formulate/exceptions.py
+++ b/src/formulate/exceptions.py
@@ -19,9 +19,9 @@ def debug_root(exp: str, error: lark.LarkError) -> ParseError:
         msg += "There was an error parsing the expression at or near this location\n"
         msg += error.get_context(exp)
     suggestions = []
-    if "&" in exp and "&&" not in exp:
+    if re.search(r"(?<!&)&(?!&)", exp):
         suggestions.append("- Use '&&' instead of '&'.")
-    if "|" in exp and "||" not in exp:
+    if re.search(r"(?<!\|)\|(?!\|)", exp):
         suggestions.append("- Use '||' instead of '|'.")
     if "~" in exp:
         suggestions.append("- Use '!' instead of '~'.")

--- a/src/formulate/exceptions.py
+++ b/src/formulate/exceptions.py
@@ -19,9 +19,9 @@ def debug_root(exp: str, error: lark.LarkError) -> ParseError:
         msg += "There was an error parsing the expression at or near this location\n"
         msg += error.get_context(exp)
     suggestions = []
-    if " & " in exp:
+    if "&" in exp and "&&" not in exp:
         suggestions.append("- Use '&&' instead of '&'.")
-    if " | " in exp:
+    if "|" in exp and "||" not in exp:
         suggestions.append("- Use '||' instead of '|'.")
     if "~" in exp:
         suggestions.append("- Use '!' instead of '~'.")

--- a/src/formulate/identifiers.py
+++ b/src/formulate/identifiers.py
@@ -309,7 +309,7 @@ ROOT_FUNCTIONS = {
 
 PYTHON_FUNCTIONS = {
     **NUMEXPR_FUNCTIONS,
-    "pow": "pow",
+    "pow": "power",
     "complex": "complex128",
 }
 
@@ -431,7 +431,7 @@ ROOT_CONSTANTS = {
 }
 
 PYTHON_CONSTANTS = {
-    **NUMEXPR_OPERATOR_SYMBOLS,
+    **NUMEXPR_CONSTANTS,
     "inf": "float('inf')",
     "neginf": "float('-inf')",
     "nan": "float('nan')",

--- a/tests/test_failures.py
+++ b/tests/test_failures.py
@@ -24,9 +24,21 @@ def test_debug_root_suggests_for_bare_ampersand():
         formulate.from_root("a&b")
 
 
+def test_debug_root_suggests_for_bare_ampersand_mixed():
+    # expression already contains && elsewhere but also has a bare &
+    with pytest.raises(formulate.ParseError, match="'&&'"):
+        formulate.from_root("a&&b&c")
+
+
 def test_debug_root_suggests_for_bare_pipe():
     with pytest.raises(formulate.ParseError, match=r"'\|\|'"):
         formulate.from_root("a|b")
+
+
+def test_debug_root_suggests_for_bare_pipe_mixed():
+    # expression already contains || elsewhere but also has a bare |
+    with pytest.raises(formulate.ParseError, match=r"'\|\|'"):
+        formulate.from_root("a||b|c")
 
 
 # Test for empty strings

--- a/tests/test_failures.py
+++ b/tests/test_failures.py
@@ -1,22 +1,10 @@
 from __future__ import annotations
 
-import inspect
-
 import pytest
 from hypothesis import assume, given, settings
 from hypothesis import strategies as st
 
 import formulate
-
-
-def test_from_root_no_kwargs():
-    sig = inspect.signature(formulate.from_root)
-    assert "kwargs" not in sig.parameters, "from_root must not accept **kwargs"
-
-
-def test_from_numexpr_no_kwargs():
-    sig = inspect.signature(formulate.from_numexpr)
-    assert "kwargs" not in sig.parameters, "from_numexpr must not accept **kwargs"
 
 
 def test_debug_root_suggests_for_bare_ampersand():

--- a/tests/test_failures.py
+++ b/tests/test_failures.py
@@ -1,10 +1,32 @@
 from __future__ import annotations
 
+import inspect
+
 import pytest
 from hypothesis import assume, given, settings
 from hypothesis import strategies as st
 
 import formulate
+
+
+def test_from_root_no_kwargs():
+    sig = inspect.signature(formulate.from_root)
+    assert "kwargs" not in sig.parameters, "from_root must not accept **kwargs"
+
+
+def test_from_numexpr_no_kwargs():
+    sig = inspect.signature(formulate.from_numexpr)
+    assert "kwargs" not in sig.parameters, "from_numexpr must not accept **kwargs"
+
+
+def test_debug_root_suggests_for_bare_ampersand():
+    with pytest.raises(formulate.ParseError, match="'&&'"):
+        formulate.from_root("a&b")
+
+
+def test_debug_root_suggests_for_bare_pipe():
+    with pytest.raises(formulate.ParseError, match=r"'\|\|'"):
+        formulate.from_root("a|b")
 
 
 # Test for empty strings

--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -208,7 +208,9 @@ def test_multiple_pow2():
     ["pi", "sqrt2", "exp1", "true", "false", "TMath::Infinity()"],
 )
 def test_constant_to_python(expr):
-    assert formulate.from_root(expr).to_python()
+    out = formulate.from_root(expr).to_python()
+    assert out
+    ast.parse(out)
 
 
 def test_function_pow_uses_np_power():

--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -199,3 +199,23 @@ def test_multiple_pow2():
     a = formulate.from_root("a^b^c^d")
     out = a.to_python()
     assert ast.unparse(ast.parse(out)) == ast.unparse(ast.parse("a**b**c**d"))
+
+
+def test_constant_pi():
+    out = formulate.from_root("pi").to_python()
+    assert ast.unparse(ast.parse(out)) is not None
+
+
+def test_constant_inf():
+    out = formulate.from_root("TMath::Infinity()").to_python()
+    assert "inf" in out
+
+
+def test_constant_sqrt2():
+    out = formulate.from_root("sqrt2").to_python()
+    assert ast.unparse(ast.parse(out)) is not None
+
+
+def test_function_pow_uses_np_power():
+    out = formulate.from_root("pow(a, 2)").to_python()
+    assert out.startswith("np.power(")

--- a/tests/test_python.py
+++ b/tests/test_python.py
@@ -2,6 +2,8 @@ from __future__ import annotations
 
 import ast
 
+import pytest
+
 import formulate
 
 
@@ -201,19 +203,12 @@ def test_multiple_pow2():
     assert ast.unparse(ast.parse(out)) == ast.unparse(ast.parse("a**b**c**d"))
 
 
-def test_constant_pi():
-    out = formulate.from_root("pi").to_python()
-    assert ast.unparse(ast.parse(out)) is not None
-
-
-def test_constant_inf():
-    out = formulate.from_root("TMath::Infinity()").to_python()
-    assert "inf" in out
-
-
-def test_constant_sqrt2():
-    out = formulate.from_root("sqrt2").to_python()
-    assert ast.unparse(ast.parse(out)) is not None
+@pytest.mark.parametrize(
+    "expr",
+    ["pi", "sqrt2", "exp1", "true", "false", "TMath::Infinity()"],
+)
+def test_constant_to_python(expr):
+    assert formulate.from_root(expr).to_python()
 
 
 def test_function_pow_uses_np_power():


### PR DESCRIPTION
This PR starts to address #81.

:robot: _AI text below_ :robot:

- identifiers.py: PYTHON_CONSTANTS spread NUMEXPR_OPERATOR_SYMBOLS instead
  of NUMEXPR_CONSTANTS, breaking to_python() for every constant except
  inf/neginf/nan (pi, sqrt2, true, false, etc. all raised ValueError)
- identifiers.py: PYTHON_FUNCTIONS mapped pow -> "pow" (emitting np.pow,
  NumPy >= 2.0 only); changed to "power" (np.power, all versions)
- __init__.py: from_root/from_numexpr accepted **kwargs they never used,
  silently swallowing typos; removed the parameter and updated docstrings
- exceptions.py: debug_root suggestions for & and | required surrounding
  spaces, so bare a&b / a|b got no hint; fixed with substring + exclusion check

Assisted-by: claude-code:claude-sonnet-4-6