### PR TITLE
fix: guard zero-arg calls and correct Matrix constant traversal

### DIFF
--- a/src/formulate/AST.py
+++ b/src/formulate/AST.py
@@ -230,7 +230,7 @@ class BinaryOperator(AST):  # Binary Operator: Operation with two operands
 
 @dataclass
 class Matrix(AST):  # Matrix: A matrix call
-    var: Symbol
+    var: AST
     indices: list[AST]
 
     def __str__(self) -> str:
@@ -256,11 +256,15 @@ class Matrix(AST):  # Matrix: A matrix call
 
     @property
     def named_constants(self) -> OrderedSet[str]:
-        return OrderedSet.union(*[ind.named_constants for ind in self.indices])
+        return OrderedSet.union(
+            self.var.named_constants, *[ind.named_constants for ind in self.indices]
+        )
 
     @property
     def unnamed_constants(self) -> OrderedSet[str]:
-        return OrderedSet.union(*[ind.unnamed_constants for ind in self.indices])
+        return OrderedSet.union(
+            self.var.unnamed_constants, *[ind.unnamed_constants for ind in self.indices]
+        )
 
 
 @dataclass
@@ -300,12 +304,18 @@ class Call(AST):  # Call: evaluate a function on arguments
 
     @property
     def variables(self) -> OrderedSet[str]:
-        return OrderedSet.union(*[arg.variables for arg in self.arguments])
+        return OrderedSet.union(
+            OrderedSet(), *[arg.variables for arg in self.arguments]
+        )
 
     @property
     def named_constants(self) -> OrderedSet[str]:
-        return OrderedSet.union(*[arg.named_constants for arg in self.arguments])
+        return OrderedSet.union(
+            OrderedSet(), *[arg.named_constants for arg in self.arguments]
+        )
 
     @property
     def unnamed_constants(self) -> OrderedSet[str]:
-        return OrderedSet.union(*[arg.unnamed_constants for arg in self.arguments])
+        return OrderedSet.union(
+            OrderedSet(), *[arg.unnamed_constants for arg in self.arguments]
+        )

--- a/src/formulate/toast.py
+++ b/src/formulate/toast.py
@@ -99,7 +99,10 @@ def toast(ptnode: lark.Tree) -> AST.AST:
                     raise SyntaxError(msg)
                 return AST.Symbol(func_name)
 
-            func_arguments = [toast(elem) for elem in trailer.children[0].children]
+            arg_list = trailer.children[0]
+            func_arguments = (
+                [] if arg_list is None else [toast(elem) for elem in arg_list.children]
+            )
             return AST.Call(func_name, func_arguments)
 
         case lark.Tree("symbol", children):

--- a/tests/test_ast_properties.py
+++ b/tests/test_ast_properties.py
@@ -1,0 +1,53 @@
+from __future__ import annotations
+
+import pytest
+
+import formulate
+from formulate.AST import Call, Literal, Matrix, Symbol
+
+
+def test_zero_arg_call_parses():
+    expr = formulate.from_root("Length$()")
+    assert isinstance(expr, Call)
+    assert expr.arguments == []
+
+
+def test_zero_arg_call_to_root():
+    assert formulate.from_root("Length$()").to_root() == "Length$()"
+
+
+def test_zero_arg_call_variables():
+    assert Call("length", []).variables == set()
+
+
+def test_zero_arg_call_named_constants():
+    assert Call("length", []).named_constants == set()
+
+
+def test_zero_arg_call_unnamed_constants():
+    assert Call("length", []).unnamed_constants == set()
+
+
+def test_matrix_named_constants_includes_base():
+    expr = formulate.from_root("pi[0]")
+    assert "pi" in expr.named_constants
+
+
+def test_matrix_named_constants_index_only():
+    expr = formulate.from_root("a[0]")
+    assert expr.named_constants == set()
+
+
+def test_matrix_unnamed_constants_includes_base_literal():
+    m = Matrix(Literal(3.14), [Symbol("i")])
+    assert 3.14 in m.unnamed_constants
+
+
+def test_matrix_variables_no_indices():
+    m = Matrix(Symbol("a"), [])
+    assert m.variables == {"a"}
+
+
+@pytest.mark.parametrize("expr", ["a[0]", "a[i]", "a[0][1]"])
+def test_matrix_named_constants_empty_when_no_constants(expr):
+    assert formulate.from_root(expr).named_constants == set()

--- a/tests/test_ast_properties.py
+++ b/tests/test_ast_properties.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import pytest
+from ordered_set import OrderedSet
 
 import formulate
 from formulate.AST import Call, Literal, Matrix, Symbol
@@ -17,15 +18,15 @@ def test_zero_arg_call_to_root():
 
 
 def test_zero_arg_call_variables():
-    assert Call("length", []).variables == set()
+    assert Call("length", []).variables == OrderedSet()
 
 
 def test_zero_arg_call_named_constants():
-    assert Call("length", []).named_constants == set()
+    assert Call("length", []).named_constants == OrderedSet()
 
 
 def test_zero_arg_call_unnamed_constants():
-    assert Call("length", []).unnamed_constants == set()
+    assert Call("length", []).unnamed_constants == OrderedSet()
 
 
 def test_matrix_named_constants_includes_base():
@@ -35,7 +36,7 @@ def test_matrix_named_constants_includes_base():
 
 def test_matrix_named_constants_index_only():
     expr = formulate.from_root("a[0]")
-    assert expr.named_constants == set()
+    assert expr.named_constants == OrderedSet()
 
 
 def test_matrix_unnamed_constants_includes_base_literal():
@@ -45,9 +46,9 @@ def test_matrix_unnamed_constants_includes_base_literal():
 
 def test_matrix_variables_no_indices():
     m = Matrix(Symbol("a"), [])
-    assert m.variables == {"a"}
+    assert m.variables == OrderedSet(["a"])
 
 
 @pytest.mark.parametrize("expr", ["a[0]", "a[i]", "a[0][1]"])
 def test_matrix_named_constants_empty_when_no_constants(expr):
-    assert formulate.from_root(expr).named_constants == set()
+    assert formulate.from_root(expr).named_constants == OrderedSet()


### PR DESCRIPTION
This PR continues to address the issues in #81

:robot: _AI text below_ :robot:

- toast.py: function branch crashed with AttributeError on zero-arg calls (e.g. Length$()) because trailer.children[0] is None for an empty arglist; add the same None guard already present in the constant branch
- AST.py Call: OrderedSet.union(*[]) raises when arguments is empty; seed the union with an empty OrderedSet() so zero-arg calls are safe
- AST.py Matrix.named_constants / unnamed_constants: ignored self.var, so from_root("pi[0]").named_constants was empty; mirror the variables property which already folds self.var in as the leading argument (this also fixes the empty-indices crash via the guaranteed first arg)
- AST.py Matrix.var: widened type annotation from Symbol to AST; toast passes the result of toast(array) which can be any AST node

Assisted-by: claude-code:claude-sonnet-4-6