### PR TITLE
fix: correct TMath::Min/Max round-trip, bare $ symbols, indexed power parse

### DIFF
--- a/src/formulate/identifiers.py
+++ b/src/formulate/identifiers.py
@@ -167,6 +167,9 @@ FUNCTIONS = {
     "min",
     "max",
     "length",
+    # TMath scalar functions that collide with array-reduction names
+    "tmath_min",
+    "tmath_max",
 }
 
 FUNCTION_ALIASES = {
@@ -216,6 +219,8 @@ NUMEXPR_FUNCTIONS = {
     "prod": "prod",
     "min": "min",
     "max": "max",
+    "tmath_min": "min",
+    "tmath_max": "max",
 }
 
 # https://root.cern.ch/doc/master/namespaceTMath.html
@@ -305,12 +310,18 @@ ROOT_FUNCTIONS = {
     "min": "Min$",
     "max": "Max$",
     "length": "Length$",
+    # Scalar two-argument functions (distinct from array reductions above)
+    "tmath_min": "TMath::Min",
+    "tmath_max": "TMath::Max",
 }
 
 PYTHON_FUNCTIONS = {
     **NUMEXPR_FUNCTIONS,
     "pow": "pow",
     "complex": "complex128",
+    # np.minimum/maximum are the element-wise equivalents of TMath::Min/Max
+    "tmath_min": "minimum",
+    "tmath_max": "maximum",
 }
 
 CONSTANTS = {

--- a/src/formulate/resources/root_grammar.lark
+++ b/src/formulate/resources/root_grammar.lark
@@ -34,15 +34,17 @@ term: factor
     | term "%" factor -> mod
 
 factor: pow
-      | factor matpos+ -> matr
       | "+" factor -> pos
       | "-" factor -> neg
       | "!" factor -> inv
 
 # Note that this is the only operation that groups from the right.
-pow: atom
-   | atom "**" factor -> pow
-   | atom "^" factor -> pow
+pow: indexed
+   | indexed "**" factor -> pow
+   | indexed "^" factor -> pow
+
+indexed: atom
+       | indexed matpos+ -> matr
 
 matpos: "[" sum "]"
 

--- a/src/formulate/toast.py
+++ b/src/formulate/toast.py
@@ -106,7 +106,11 @@ def toast(ptnode: lark.Tree) -> AST.AST:
                     raise SyntaxError(msg)
                 return AST.Symbol(func_name)
 
-            func_arguments = [toast(elem) for elem in trailer.children[0].children]
+            arglist = trailer.children[0]
+            func_arguments = [
+                toast(elem)
+                for elem in (arglist.children if arglist is not None else [])
+            ]
             return AST.Call(func_name, func_arguments)
 
         case lark.Tree("symbol", children):

--- a/src/formulate/toast.py
+++ b/src/formulate/toast.py
@@ -45,9 +45,16 @@ def _get_function_name(node: lark.Tree) -> str:
     if len(pieces) == 1:
         name = pieces[0]
     elif len(pieces) == 2:
-        if pieces[0].lower() not in NAMESPACES:
+        namespace = pieces[0].lower()
+        if namespace not in NAMESPACES:
             msg = f'Unknown namespace "{pieces[0]}"'
             raise ValueError(msg)
+        # Build a namespace-qualified identifier for functions that have both
+        # a namespaced scalar form (TMath::Min) and a bare array form (Min$).
+        func_lower = pieces[1].lower().rstrip("$")
+        qualified = f"{namespace}_{func_lower}"
+        if qualified in FUNCTIONS:
+            return qualified
         name = pieces[1]
     else:
         msg = f'Unknown function or constant "{full_name}"'
@@ -106,6 +113,11 @@ def toast(ptnode: lark.Tree) -> AST.AST:
             var_name = _get_var_name(children[0])
             if var_name in ("True", "False"):
                 var_name = var_name.lower()  # This makes it not a keyword
+            # Bare ROOT $ functions (e.g. Length$, Sum$) used without parens
+            if var_name.endswith("$"):
+                func_name = var_name[:-1].lower()
+                if func_name in FUNCTIONS:
+                    return AST.Call(func_name, [])
             if any(
                 not part.isidentifier() or iskeyword(part)
                 for part in var_name.split(".")

--- a/tests/test_root_semantics.py
+++ b/tests/test_root_semantics.py
@@ -1,0 +1,93 @@
+from __future__ import annotations
+
+import pytest
+
+import formulate
+from formulate.AST import BinaryOperator, Call, Matrix
+
+# --- TMath::Min / TMath::Max round-trip (issue: both collapsed to Min$/Max$) ---
+
+
+def test_tmath_min_roundtrip():
+    expr = formulate.from_root("TMath::Min(a, b)")
+    assert expr.to_root() == "TMath::Min(a, b)"
+
+
+def test_tmath_max_roundtrip():
+    expr = formulate.from_root("TMath::Max(a, b)")
+    assert expr.to_root() == "TMath::Max(a, b)"
+
+
+def test_array_min_roundtrip():
+    expr = formulate.from_root("Min$(arr)")
+    assert expr.to_root() == "Min$(arr)"
+
+
+def test_array_max_roundtrip():
+    expr = formulate.from_root("Max$(arr)")
+    assert expr.to_root() == "Max$(arr)"
+
+
+def test_tmath_min_distinct_from_array_min():
+    scalar = formulate.from_root("TMath::Min(a, b)")
+    array = formulate.from_root("Min$(arr)")
+    assert scalar.to_root() != array.to_root()
+
+
+def test_tmath_min_to_python():
+    out = formulate.from_root("TMath::Min(a, b)").to_python()
+    assert out == "np.minimum(a, b)"
+
+
+def test_tmath_max_to_python():
+    out = formulate.from_root("TMath::Max(a, b)").to_python()
+    assert out == "np.maximum(a, b)"
+
+
+# --- Bare $ functions without parentheses ---
+
+
+def test_bare_length_dollar():
+    expr = formulate.from_root("Length$")
+    assert isinstance(expr, Call)
+    assert expr.function == "length"
+    assert expr.arguments == []
+
+
+def test_bare_sum_dollar():
+    expr = formulate.from_root("Sum$")
+    assert isinstance(expr, Call)
+    assert expr.function == "sum"
+
+
+def test_bare_dollar_in_expression():
+    expr = formulate.from_root("Sum$(pt)/Length$")
+    assert isinstance(expr, BinaryOperator)
+
+
+def test_bare_length_to_root():
+    assert formulate.from_root("Length$").to_root() == "Length$()"
+
+
+# --- Indexing before power: a[0]**2 ---
+
+
+@pytest.mark.parametrize(
+    "expr",
+    [
+        "a[0]**2",
+        "a[0]^2",
+        "a[0][1]**2",
+        "a[i]**b",
+    ],
+)
+def test_indexed_power_parses(expr):
+    result = formulate.from_root(expr)
+    assert isinstance(result, BinaryOperator)
+    assert result.operator == "pow"
+    assert isinstance(result.left, Matrix)
+
+
+def test_indexed_power_roundtrip():
+    expr = formulate.from_root("a[0]**2")
+    assert "**" in expr.to_root()

--- a/tests/test_root_semantics.py
+++ b/tests/test_root_semantics.py
@@ -69,6 +69,11 @@ def test_bare_length_to_root():
     assert formulate.from_root("Length$").to_root() == "Length$()"
 
 
+def test_bare_length_dollar_roundtrip():
+    serialized = formulate.from_root("Length$").to_root()
+    assert formulate.from_root(serialized).to_root() == serialized
+
+
 # --- Indexing before power: a[0]**2 ---
 
 


### PR DESCRIPTION
This PR continues to fix issues in #81.

:robot: _AI text below_ :robot:

- root_grammar.lark: introduce an `indexed` level between `atom` and `pow` so that `a[0]**2` parses correctly; previously pow required an atom on the left, but indexing (matr) lived at the factor level, making `Jet_pt[0]**2` a parse error
- identifiers.py: add tmath_min / tmath_max as distinct canonical identifiers; TMath::Min(a,b) (scalar) and Min$(arr) (array reduction) both normalized to "min" and silently round-tripped as Min$; tmath_min maps to TMath::Min in ROOT, min in numexpr, and np.minimum in Python
- toast.py (_get_function_name): when a namespaced call like TMath::Min is seen, build the qualified name (tmath_min) and return it directly if it exists in FUNCTIONS, before falling through to the bare name lookup
- toast.py (symbol case): bare ROOT $ functions (Length$, Sum$, Min$, Max$) used without parentheses raised SyntaxError because $ is not a valid Python identifier; detect the $ suffix and produce a zero-arg Call instead

Assisted-by: claude-code:claude-sonnet-4-6