### PR TITLE
refactor: simplify AST backends, exception helpers, and toast parsing

### DIFF
--- a/src/formulate/AST.py
+++ b/src/formulate/AST.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 from abc import ABCMeta, abstractmethod
 from dataclasses import dataclass
+from typing import Any
 
 from ordered_set import OrderedSet
 
@@ -21,44 +22,75 @@ from .identifiers import (
 )
 
 
+@dataclass
+class _Backend:
+    name: str
+    operator_symbols: dict[str, str]
+    functions: dict[str, Any]
+    constants: dict[str, Any]
+    function_prefix: str = ""
+    pow_as_operator: bool = False
+    unparenthesized_ops: frozenset[str] = frozenset()
+    index_format: str | None = (
+        "python"  # None = forbidden, "root" = [x][y], "python" = [x,y]
+    )
+
+
+_NUMEXPR = _Backend(
+    name="NumExpr",
+    operator_symbols=NUMEXPR_OPERATOR_SYMBOLS,
+    functions=NUMEXPR_FUNCTIONS,
+    constants=NUMEXPR_CONSTANTS,
+    pow_as_operator=True,
+    index_format=None,
+)
+
+_ROOT = _Backend(
+    name="ROOT",
+    operator_symbols=ROOT_OPERATOR_SYMBOLS,
+    functions=ROOT_FUNCTIONS,
+    constants=ROOT_CONSTANTS,
+    unparenthesized_ops=frozenset({":"}),
+    index_format="root",
+)
+
+_PYTHON = _Backend(
+    name="Python",
+    operator_symbols=PYTHON_OPERATOR_SYMBOLS,
+    functions=PYTHON_FUNCTIONS,
+    constants=PYTHON_CONSTANTS,
+    function_prefix="np.",
+    unparenthesized_ops=frozenset({","}),
+)
+
+
 class AST(metaclass=ABCMeta):
     @abstractmethod
-    def __str__(self) -> str:
-        msg = "__str__() not implemented, subclass must implement it"
-        raise NotImplementedError(msg)
+    def __str__(self) -> str: ...
 
     @abstractmethod
+    def _to_backend(self, backend: _Backend) -> str: ...
+
     def to_numexpr(self) -> str:
-        msg = "to_numexpr() not implemented, subclass must implement it"
-        raise NotImplementedError(msg)
+        return self._to_backend(_NUMEXPR)
 
-    @abstractmethod
     def to_root(self) -> str:
-        msg = "to_root() not implemented, subclass must implement it"
-        raise NotImplementedError(msg)
+        return self._to_backend(_ROOT)
 
-    @abstractmethod
     def to_python(self) -> str:
-        msg = "to_python() not implemented, subclass must implement it"
-        raise NotImplementedError(msg)
+        return self._to_backend(_PYTHON)
 
     @property
     @abstractmethod
-    def variables(self) -> OrderedSet[str]:
-        msg = "variables() not implemented, subclass must implement it"
-        raise NotImplementedError(msg)
+    def variables(self) -> OrderedSet[str]: ...
 
     @property
     @abstractmethod
-    def named_constants(self) -> OrderedSet[str]:
-        msg = "named_constants() not implemented, subclass must implement it"
-        raise NotImplementedError(msg)
+    def named_constants(self) -> OrderedSet[str]: ...
 
     @property
     @abstractmethod
-    def unnamed_constants(self) -> OrderedSet[str]:
-        msg = "unnamed_constants() not implemented, subclass must implement it"
-        raise NotImplementedError(msg)
+    def unnamed_constants(self) -> OrderedSet[str]: ...
 
 
 @dataclass
@@ -68,13 +100,7 @@ class Literal(AST):  # Literal: value that appears in the program text
     def __str__(self) -> str:
         return str(self.value)
 
-    def to_numexpr(self) -> str:
-        return repr(self.value)
-
-    def to_root(self) -> str:
-        return repr(self.value)
-
-    def to_python(self) -> str:
+    def _to_backend(self, _backend: _Backend) -> str:
         return repr(self.value)
 
     @property
@@ -97,29 +123,11 @@ class Symbol(AST):  # Symbol: value referenced by name
     def __str__(self) -> str:
         return self.name
 
-    def to_numexpr(self) -> str:
+    def _to_backend(self, backend: _Backend) -> str:
         if self.name in CONSTANTS:
-            const = NUMEXPR_CONSTANTS.get(self.name, None)
+            const = backend.constants.get(self.name)
             if const is None:
-                msg = f'Constant "{self.name}" is not supported in NumExpr.'
-                raise ValueError(msg)
-            return str(const)
-        return self.name
-
-    def to_root(self) -> str:
-        if self.name in CONSTANTS:
-            const = ROOT_CONSTANTS.get(self.name, None)
-            if const is None:
-                msg = f'Constant "{self.name}" is not supported in ROOT.'
-                raise ValueError(msg)
-            return str(const)
-        return self.name
-
-    def to_python(self) -> str:
-        if self.name in CONSTANTS:
-            const = PYTHON_CONSTANTS.get(self.name, None)
-            if const is None:
-                msg = f'Constant "{self.name}" is not supported in Python.'
+                msg = f'Constant "{self.name}" is not supported in {backend.name}.'
                 raise ValueError(msg)
             return str(const)
         return self.name
@@ -145,26 +153,12 @@ class UnaryOperator(AST):  # Unary Operator: Operation with one operand
     def __str__(self) -> str:
         return f"{self.operator}({self.operand})"
 
-    def to_numexpr(self) -> str:
-        symbol = NUMEXPR_OPERATOR_SYMBOLS.get(self.operator, None)
+    def _to_backend(self, backend: _Backend) -> str:
+        symbol = backend.operator_symbols.get(self.operator)
         if symbol is None:
-            msg = f'Operator "{self.operator}" is not supported in NumExpr.'
+            msg = f'Operator "{self.operator}" is not supported in {backend.name}.'
             raise ValueError(msg)
-        return f"({symbol}{self.operand.to_numexpr()})"
-
-    def to_root(self) -> str:
-        symbol = ROOT_OPERATOR_SYMBOLS.get(self.operator, None)
-        if symbol is None:
-            msg = f'Operator "{self.operator}" is not supported in ROOT.'
-            raise ValueError(msg)
-        return f"({symbol}{self.operand.to_root()})"
-
-    def to_python(self) -> str:
-        symbol = PYTHON_OPERATOR_SYMBOLS.get(self.operator, None)
-        if symbol is None:
-            msg = f'Operator "{self.operator}" is not supported in Python.'
-            raise ValueError(msg)
-        return f"({symbol}{self.operand.to_python()})"
+        return f"({symbol}{self.operand._to_backend(backend)})"
 
     @property
     def variables(self) -> OrderedSet[str]:
@@ -188,30 +182,13 @@ class BinaryOperator(AST):  # Binary Operator: Operation with two operands
     def __str__(self) -> str:
         return f"{self.operator}({self.left}, {self.right})"
 
-    def to_numexpr(self) -> str:
-        symbol = NUMEXPR_OPERATOR_SYMBOLS.get(self.operator, None)
+    def _to_backend(self, backend: _Backend) -> str:
+        symbol = backend.operator_symbols.get(self.operator)
         if symbol is None:
-            msg = f'Operator "{self.operator}" is not supported in NumExpr.'
+            msg = f'Operator "{self.operator}" is not supported in {backend.name}.'
             raise ValueError(msg)
-        return f"({self.left.to_numexpr()} {symbol} {self.right.to_numexpr()})"
-
-    def to_root(self) -> str:
-        symbol = ROOT_OPERATOR_SYMBOLS.get(self.operator, None)
-        if symbol is None:
-            msg = f'Operator "{self.operator}" is not supported in ROOT.'
-            raise ValueError(msg)
-        out = f"{self.left.to_root()} {symbol} {self.right.to_root()}"
-        if symbol != ":":
-            out = f"({out})"
-        return out
-
-    def to_python(self) -> str:
-        symbol = PYTHON_OPERATOR_SYMBOLS.get(self.operator, None)
-        if symbol is None:
-            msg = f'Operator "{self.operator}" is not supported in Python.'
-            raise ValueError(msg)
-        out = f"{self.left.to_python()} {symbol} {self.right.to_python()}"
-        if symbol != ",":
+        out = f"{self.left._to_backend(backend)} {symbol} {self.right._to_backend(backend)}"
+        if symbol not in backend.unparenthesized_ops:
             out = f"({out})"
         return out
 
@@ -230,23 +207,26 @@ class BinaryOperator(AST):  # Binary Operator: Operation with two operands
 
 @dataclass
 class Matrix(AST):  # Matrix: A matrix call
-    var: Symbol
+    var: AST
     indices: list[AST]
 
     def __str__(self) -> str:
         return "{}[{}]".format(str(self.var), ", ".join(str(x) for x in self.indices))
 
-    def to_numexpr(self) -> str:
-        msg = "Matrix operations are forbidden in Numexpr."
-        raise ValueError(msg)
-
-    def to_root(self) -> str:
-        index = "".join(f"[{elem.to_root()}]" for elem in self.indices)
-        return self.var.to_root() + index
-
-    def to_python(self) -> str:
-        index = ", ".join(f"{elem.to_python()}" for elem in self.indices)
-        return f"{self.var.to_python()}[{index}]"
+    def _to_backend(self, backend: _Backend) -> str:
+        if backend.index_format is None:
+            msg = f"Matrix operations are forbidden in {backend.name}."
+            raise ValueError(msg)
+        var_str = self.var._to_backend(backend)
+        if backend.index_format == "root":
+            index = "".join(f"[{elem._to_backend(backend)}]" for elem in self.indices)
+        else:
+            index = (
+                "["
+                + ", ".join(elem._to_backend(backend) for elem in self.indices)
+                + "]"
+            )
+        return var_str + index
 
     @property
     def variables(self) -> OrderedSet[str]:
@@ -271,32 +251,15 @@ class Call(AST):  # Call: evaluate a function on arguments
     def __str__(self) -> str:
         return f"{self.function}({', '.join(str(x) for x in self.arguments)})"
 
-    def to_numexpr(self) -> str:
-        function_str = NUMEXPR_FUNCTIONS.get(self.function, None)
-        if self.function == "pow":
-            # pow needs to be written with this notation in NumExpr
-            return f"({self.arguments[0].to_numexpr()} ** {self.arguments[1].to_numexpr()})"
+    def _to_backend(self, backend: _Backend) -> str:
+        if backend.pow_as_operator and self.function == "pow":
+            return f"({self.arguments[0]._to_backend(backend)} ** {self.arguments[1]._to_backend(backend)})"
+        function_str = backend.functions.get(self.function)
         if function_str is None:
-            msg = f'Function "{self.function}" is not supported in NumExpr.'
+            msg = f'Function "{self.function}" is not supported in {backend.name}.'
             raise ValueError(msg)
-        arguments = ", ".join(arg.to_numexpr() for arg in self.arguments)
-        return f"{function_str}({arguments})"
-
-    def to_root(self) -> str:
-        function_str = ROOT_FUNCTIONS.get(self.function, None)
-        if function_str is None:
-            msg = f'Function "{self.function}" is not supported in ROOT.'
-            raise ValueError(msg)
-        arguments = ", ".join(arg.to_root() for arg in self.arguments)
-        return f"{function_str}({arguments})"
-
-    def to_python(self) -> str:
-        function_str = PYTHON_FUNCTIONS.get(self.function, None)
-        if function_str is None:
-            msg = f'Function "{self.function}" is not supported in Python.'
-            raise ValueError(msg)
-        arguments = ", ".join(arg.to_python() for arg in self.arguments)
-        return f"np.{function_str}({arguments})"
+        arguments = ", ".join(arg._to_backend(backend) for arg in self.arguments)
+        return f"{backend.function_prefix}{function_str}({arguments})"
 
     @property
     def variables(self) -> OrderedSet[str]:

--- a/src/formulate/exceptions.py
+++ b/src/formulate/exceptions.py
@@ -13,19 +13,14 @@ class ParseError(Exception):
         self.lark_error = lark_error
 
 
-def debug_root(exp: str, error: lark.LarkError) -> ParseError:
+def _build_parse_error(
+    exp: str, error: lark.LarkError, suggestions: list[str]
+) -> ParseError:
     msg = ""
     if isinstance(error, lark.UnexpectedInput):
         msg += "There was an error parsing the expression at or near this location\n"
         msg += error.get_context(exp)
-    suggestions = []
-    if " & " in exp:
-        suggestions.append("- Use '&&' instead of '&'.")
-    if " | " in exp:
-        suggestions.append("- Use '||' instead of '|'.")
-    if "~" in exp:
-        suggestions.append("- Use '!' instead of '~'.")
-    if len(suggestions) > 0:
+    if suggestions:
         msg += "\nHere are some suggestions for how to fix the error:\n"
         msg += "\n".join(suggestions)
         msg += "\n"
@@ -36,11 +31,18 @@ def debug_root(exp: str, error: lark.LarkError) -> ParseError:
     return ParseError(msg, error)
 
 
+def debug_root(exp: str, error: lark.LarkError) -> ParseError:
+    suggestions = []
+    if " & " in exp:
+        suggestions.append("- Use '&&' instead of '&'.")
+    if " | " in exp:
+        suggestions.append("- Use '||' instead of '|'.")
+    if "~" in exp:
+        suggestions.append("- Use '!' instead of '~'.")
+    return _build_parse_error(exp, error, suggestions)
+
+
 def debug_numexpr(exp: str, error: lark.LarkError) -> ParseError:
-    msg = ""
-    if isinstance(error, lark.UnexpectedInput):
-        msg += "There was an error parsing the expression at or near this location\n"
-        msg += error.get_context(exp)
     suggestions = []
     if "&&" in exp or " and " in exp:
         suggestions.append("- Use '&' instead of '&&' or 'and'.")
@@ -52,12 +54,4 @@ def debug_numexpr(exp: str, error: lark.LarkError) -> ParseError:
         suggestions.append(
             "- Make sure you don't have chained comparisons (e.g., 'a < b < c'), as these are not supported."
         )
-    if len(suggestions) > 0:
-        msg += "\nHere are some suggestions for how to fix the error:\n"
-        msg += "\n".join(suggestions)
-        msg += "\n"
-    else:
-        msg += "\nNo suggestions available.\n"
-    msg += "\nHere is the Lark error message:\n"
-    msg += str(error)
-    return ParseError(msg, error)
+    return _build_parse_error(exp, error, suggestions)

--- a/src/formulate/identifiers.py
+++ b/src/formulate/identifiers.py
@@ -185,7 +185,6 @@ FUNCTION_ALIASES = {
 NUMEXPR_FUNCTIONS = {
     "sqrt": "sqrt",
     "abs": "abs",
-    "pow": "",  # This one is a special case since it needs to be written with **
     "log": "log",
     "log10": "log10",
     "log1p": "log1p",

--- a/src/formulate/toast.py
+++ b/src/formulate/toast.py
@@ -28,20 +28,20 @@ def _get_var_name(node: lark.Tree | lark.Token) -> str:
     return CONSTANTS_ALIASES.get(var_name, var_name)
 
 
-def _get_raw_function_name(func_names: lark.Tree, invert: bool = True) -> list[str]:
-    children = []
-    if len(func_names.children) > 1:
-        children.extend(_get_raw_function_name(func_names.children[1], False))
-    children.append(func_names.children[0])
-    if invert:
-        children.reverse()
-    return children
+def _get_raw_function_name(node: lark.Tree) -> list[str]:
+    parts = []
+    while True:
+        parts.append(str(node.children[0]))
+        if len(node.children) == 1:
+            break
+        node = node.children[1]
+    return parts
 
 
 def _get_function_name(node: lark.Tree) -> str:
-    raw_name = _get_raw_function_name(node)
-    full_name = "::".join(raw_name)
-    pieces = full_name.replace(".", "::").split("::")
+    pieces = []
+    for part in _get_raw_function_name(node):
+        pieces.extend(part.replace(".", "::").split("::"))
     if len(pieces) == 1:
         name = pieces[0]
     elif len(pieces) == 2:
@@ -50,6 +50,7 @@ def _get_function_name(node: lark.Tree) -> str:
             raise ValueError(msg)
         name = pieces[1]
     else:
+        full_name = "::".join(pieces)
         msg = f'Unknown function or constant "{full_name}"'
         raise ValueError(msg)
     # Now we normalize the name and make sure it is supported


### PR DESCRIPTION
This PR continues addressing the issues from #81.

:robot: _AI text below_ :robot:

- Add _Backend dataclass to AST.py; add _to_backend() to each node so to_numexpr/to_root/to_python become one-liner delegations
- Extract _build_parse_error() shared helper from debug_root/debug_numexpr to eliminate ~20 lines of duplication
- Remove dead "pow": "" sentinel from NUMEXPR_FUNCTIONS; pow-as-operator behaviour is now encoded in _Backend.pow_as_operator
- Replace unreachable raise NotImplementedError bodies in abstract methods with ...
- Simplify _get_raw_function_name from recursion to a plain loop
- Eliminate the join/split round-trip in _get_function_name

Assisted-by: claude-code:claude-sonnet-4-6