### PR TITLE
docs: overhaul the documentation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,8 +56,7 @@ jobs:
 
       - name: Install package
         run: |
-          uv pip install pytest-cov
-          uv pip install -U .[dev,test]
+          uv pip install -U .[test]
 
       - name: Test with pytest
         run: |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,11 +32,10 @@ prek run --all-files        # ruff, ruff-format, mypy (strict, src only), codesp
 and what `nox -s lint` runs. pre-commit.ci (configured by the `ci:` block in the config) still
 runs `pre-commit` proper on pull requests, so hooks must stay compatible with both.
 
-`tests/test_constants.py` is the only file that evaluates expressions with the real engines;
-it `importorskip`s `ROOT`, which CI installs only on Linux/Python 3.10. Everything else runs
-everywhere. `numexpr` is not a test dependency in `pyproject.toml` (it comes in via `[docs]`),
-so a bare `pip install -e ".[test]"` will skip nothing but will fail to import `numexpr` in
-`test_constants.py` — install `.[dev]`.
+`tests/test_constants.py` is the only file that evaluates expressions with the real engines.
+It imports `numexpr` at module scope — so `numexpr` is in the `test` extra, not just `docs`,
+or the suite cannot be collected at all — and `importorskip`s `ROOT`, which CI installs only
+on Linux/Python 3.10. So `.[test]` runs everything except the ROOT half, which skips.
 
 ## Architecture
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,7 +54,7 @@ Pipeline, in order:
    Unknown names raise here. `toast` itself is one `_traversal.fold` call; `_expand` is what
    handles a single parse-tree node, returning the children still to convert plus a builder
    that assembles the AST node from them.
-3. **`AST.py`** — five frozen dataclass node types (`Literal`, `Symbol`, `UnaryOperator`,
+3. **`AST.py`** — six frozen dataclass node types (`Literal`, `Symbol`, `UnaryOperator`,
    `BinaryOperator`, `Matrix`, `Call`) plus a `_Backend` descriptor. A node type implements
    exactly three things: `_children()`, `_format(*parts)` for `str()`, and
    `_serializer(backend)`, which returns the builder that joins its already-serialized
@@ -95,7 +95,26 @@ is supported, plus any spelling in `FUNCTION_ALIASES` / `CONSTANTS_ALIASES` /
 `CONSTANTS_FUNCTION_ALIASES`. `tests/test_identifiers.py` drives every table entry through the
 parser and cross-checks the tables against each other, so a declared-but-unmapped name fails
 loudly. If the name has both a scalar `TMath::` form and an array `$` form (as with
-`Min`/`Max`), it needs the `tmath_`-prefixed qualified variant — see `_get_function_name`.
+`Min`/`Max`), it needs the `tmath_`-prefixed qualified variant — see `_get_function_name` —
+and an entry in `FUNCTION_DISPLAY_NAMES`, since that canonical name is one nobody writes and
+would be meaningless in an error message.
+Each table also carries an attribute docstring, which is what the API page renders; the
+name additionally needs a row in the tables in `docs/guide/expressions.rst`, which nothing
+checks automatically.
+
+### Docs
+
+`docs/` is Sphinx (RTD theme, `nox -s docs`, `-- --serve` to serve). Two things to know
+before editing it:
+
+- **Examples execute at build time.** Narrative pages use `jupyter-execute`, not
+  `code-block`, wherever an output is shown, so a stale example fails the build instead of
+  lying on the website. Keep it that way — if you add an example with output, run it.
+- **Which page owns what.** `guide/expressions.rst` is the reference for every supported
+  operator, function and constant, and how each is spelled per backend; `guide/issues.rst`
+  is the reference for where the languages disagree. Behaviour changes belong in one of
+  those two. API pages are `automodule`/`autodata` over the docstrings, so the docstring is
+  where API prose goes, not the `.rst`.
 
 ### Unsupported constructs
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,31 @@
 # Changelog
 
+## Unreleased
+
+No breaking changes. This is a bug-fix and maintenance release.
+
+### Bug fixes
+
+- `to_python()` raised for every named constant except `inf`, `neginf` and `nan`, because the Python constant table was built from the wrong source. All of them now convert.
+- `to_python()` emitted `np.pow`, which only exists in NumPy 2.0 and later; it now emits `np.power`.
+- `TMath::Min(a, b)` and `TMath::Max(a, b)`, which are element-wise two-argument functions, were conflated with the `Min$`/`Max$` array reductions and silently round-tripped as the wrong one. They are now distinct, and convert to `np.minimum`/`np.maximum` in Python. They have no numexpr equivalent, and say so rather than converting.
+- ROOT's `$` functions used without parentheses, such as a bare `Length$`, are now parsed.
+- An index followed by a power, such as `Jet_pt[0]**2`, was a parse error in ROOT.
+- Zero-argument calls such as `Length$()` raised an internal error.
+- `named_constants` and `unnamed_constants` ignored the indexed expression itself, so `pi[0]` reported no constants.
+- `from_root()` and `from_numexpr()` accepted arbitrary keyword arguments and silently ignored them, turning a typo into a no-op.
+- The ROOT parse-error hints missed a bare `&` or `|` written without surrounding spaces.
+- Converting `TMath::Min`/`TMath::Max` to numexpr reported the internal name (`Function "tmath_min" is not supported`) rather than what was written.
+
+### Improvements
+
+- Expression trees are now walked iteratively throughout, so deeply nested expressions are limited by memory rather than by Python's recursion limit.
+- AST nodes are immutable (frozen, slotted dataclasses).
+- Each grammar is compiled on first use rather than at import, so parsing only one language costs only one parser.
+- The package ships a `py.typed` marker, so type checkers now see its annotations.
+- The documentation has been substantially expanded: every supported operator, function and constant is now listed with its spelling in each language, and the API reference is generated from real docstrings.
+- Python 3.14, including the free-threaded build, is tested in CI.
+
 ## v1.0.1 (16 Oct. 2025)
 
 This release provided significant bug fixes and cleanup with respect to the previous overhaul. The switch to Lark as the parsing backend and the internal AST were kept, but the code was significantly simplified and many issues were ironed out.

--- a/README.md
+++ b/README.md
@@ -149,12 +149,10 @@ Run `formulate --help` for the full list of options.
 - [API reference](https://formulate.readthedocs.io/en/latest/api/api.html)
 - [Contributing](https://formulate.readthedocs.io/en/latest/contributing/contributing.html)
 
-## Caveats
+## Limitations
 
-`%` is the one operator whose meaning changes when converted: ROOT truncates
-its operands to integers, numexpr does floating-point modulo, and the two only
-agree for non-negative whole numbers. Everything else that has no equivalent in
-the target language raises `ValueError` rather than converting to something
-subtly different. See [Common
-Issues](https://formulate.readthedocs.io/en/latest/guide/issues.html) for the
-details.
+Anything with no faithful equivalent in the target language raises `ValueError`
+rather than converting to something subtly different. The one exception is `%`,
+which converts silently even though ROOT and numexpr do not compute the same
+thing. See [Common
+Issues](https://formulate.readthedocs.io/en/latest/guide/issues.html).

--- a/README.md
+++ b/README.md
@@ -1,5 +1,3 @@
-# formulate
-
 [![Actions Status][actions-badge]][actions-link]
 [![Documentation Status][rtd-badge]][rtd-link]
 [![codecov](https://codecov.io/gh/scikit-hep/formulate/graph/badge.svg?token=W5wXQ9wcvN)](https://codecov.io/gh/scikit-hep/formulate)
@@ -29,11 +27,19 @@
 
 # Formulate
 
-Easy conversions between different styles of expressions. Formulate
-currently supports converting between
-[ROOT](https://root.cern.ch/doc/master/classTFormula.html) and
-[numexpr](https://numexpr.readthedocs.io/en/latest/user_guide.html)
-style expressions.
+Easy conversions between different styles of expressions. Formulate converts in
+either direction between
+[ROOT](https://root.cern.ch/doc/master/classTFormula.html) (`TTreeFormula`) and
+[numexpr](https://numexpr.readthedocs.io/en/latest/user_guide.html) style
+expressions, and can also render a parsed expression as plain Python using
+NumPy functions.
+
+It needs neither ROOT nor numexpr installed — it reads and writes their syntax,
+it does not evaluate anything — and it knows the places where the two languages
+disagree, such as `&&` and `&` binding differently against comparisons, or `^`
+meaning exponentiation in one and XOR in the other.
+
+Full documentation: <https://formulate.readthedocs.io/>
 
 ## Installation
 
@@ -82,6 +88,28 @@ Similarly, when starting with a `numexpr` style expression:
 '((X_PT > 5) & ((Mu_NHits > 3) | (Mu_PT > 10)))'
 ```
 
+Any parsed expression can also be rendered as Python, using NumPy for the
+functions. This direction is output-only — there is no `from_python`:
+
+```pycon
+>>> momentum.to_python()
+'np.sqrt((((X_PX ** 2) + (X_PY ** 2)) + (X_PZ ** 2)))'
+```
+
+Parsing is separate from rendering, so parse once and convert as many times as
+you like. An expression also reports what it refers to, which is how you work
+out what a selection needs to read:
+
+```pycon
+>>> expression = formulate.from_root("TMath::Sqrt(px**2 + py**2) > 5 * TMath::Pi() + 1.5")
+>>> list(expression.variables)
+['px', 'py']
+>>> list(expression.named_constants)
+['pi']
+>>> list(expression.unnamed_constants)
+[2, 5, 1.5]
+```
+
 ### CLI
 
 The package also provides a command-line interface for converting expressions between different styles. To use it, simply run the `formulate` command followed by the input expression and the desired output.
@@ -92,6 +120,9 @@ $ formulate --from-root '(A && B) || TMath::Sqrt(A)' --to-numexpr
 
 $ formulate --from-numexpr '(A & B) | sqrt(A)' --to-root
 ((A && B) || TMath::Sqrt(A))
+
+$ formulate --from-root 'TMath::Sqrt(A)' --to-python
+np.sqrt(A)
 
 $ formulate --from-root '(A && B) || TMath::Sqrt(1.23) * e_num**1.2 + 5*pi' --variables
 A
@@ -106,6 +137,17 @@ $ formulate --from-root '(A && B) || TMath::Sqrt(1.23) * e_num**1.2 + 5*pi' --un
 1.2
 5
 ```
+
+Run `formulate --help` for the full list of options.
+
+## Documentation
+
+- [Supported expressions](https://formulate.readthedocs.io/en/latest/guide/expressions.html) —
+  every operator, function and constant, and how each is spelled in each language
+- [Common issues](https://formulate.readthedocs.io/en/latest/guide/issues.html) —
+  where the languages disagree, and what formulate does about it
+- [API reference](https://formulate.readthedocs.io/en/latest/api/api.html)
+- [Contributing](https://formulate.readthedocs.io/en/latest/contributing/contributing.html)
 
 ## Caveats
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 [![Scikit-HEP][sk-badge]](https://scikit-hep.org/)
 
 <!-- prettier-ignore-start -->
-[actions-badge]:            https://github.com/scikit-hep/formulate/workflows/unittests/badge.svg
+[actions-badge]:            https://github.com/scikit-hep/formulate/actions/workflows/ci.yml/badge.svg
 [actions-link]:             https://github.com/Scikit-HEP/formulate/actions
 [conda-badge]:              https://img.shields.io/conda/vn/conda-forge/formulate
 [conda-link]:               https://github.com/conda-forge/formulate-feedstock

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
 [pypi-platforms]:           https://img.shields.io/pypi/pyversions/formulate
 [pypi-version]:             https://img.shields.io/pypi/v/formulate
 [rtd-badge]:                https://readthedocs.org/projects/formulate/badge/?version=latest
-[rtd-link]:                 https://formulate.readthedocs.io/en/latest/?badge=latest
+[rtd-link]:                 https://formulate.readthedocs.io/latest/?badge=latest
 [sk-badge]:                 https://scikit-hep.org/assets/images/Scikit--HEP-Project-blue.svg
 
 <!-- prettier-ignore-end -->
@@ -142,17 +142,10 @@ Run `formulate --help` for the full list of options.
 
 ## Documentation
 
-- [Supported expressions](https://formulate.readthedocs.io/en/latest/guide/expressions.html) —
+- [Full documentation](https://formulate.readthedocs.io/)
+- [Supported expressions](https://formulate.readthedocs.io/latest/guide/expressions.html) —
   every operator, function and constant, and how each is spelled in each language
-- [Common issues](https://formulate.readthedocs.io/en/latest/guide/issues.html) —
+- [Common issues](https://formulate.readthedocs.io/latest/guide/issues.html) —
   where the languages disagree, and what formulate does about it
-- [API reference](https://formulate.readthedocs.io/en/latest/api/api.html)
-- [Contributing](https://formulate.readthedocs.io/en/latest/contributing/contributing.html)
-
-## Limitations
-
-Anything with no faithful equivalent in the target language raises `ValueError`
-rather than converting to something subtly different. The one exception is `%`,
-which converts silently even though ROOT and numexpr do not compute the same
-thing. See [Common
-Issues](https://formulate.readthedocs.io/en/latest/guide/issues.html).
+- [API reference](https://formulate.readthedocs.io/latest/api/api.html)
+- [Contributing](https://formulate.readthedocs.io/latest/contributing/contributing.html)

--- a/docs/api/api.rst
+++ b/docs/api/api.rst
@@ -1,7 +1,22 @@
 API Reference
 ======================
 
-This section provides detailed documentation for Formulate's API.
+Formulate's public interface is small: two functions that parse, and one class
+whose methods and properties do everything else.
+
+.. code-block:: pycon
+
+   >>> import formulate
+   >>> expression = formulate.from_root("TMath::Sqrt(x**2 + y**2) > 10")
+   >>> expression.to_numexpr()
+   '(sqrt(((x ** 2) + (y ** 2))) > 10)'
+   >>> list(expression.variables)
+   ['x', 'y']
+
+:doc:`modules/formulate` covers the parsing functions, and
+:doc:`modules/ast` the expression objects they return. The remaining pages
+document the internals: the lookup tables that decide how each name is spelled
+in each language, the parse-tree conversion, and the exceptions.
 
 .. toctree::
    :maxdepth: 1

--- a/docs/api/modules/ast.rst
+++ b/docs/api/modules/ast.rst
@@ -1,9 +1,11 @@
 Abstract Syntax Tree (AST)
 ===========================
 
-This module provides the Abstract Syntax Tree (AST) for Formulate.
+The node classes below are documented because they are what you see when you
+inspect or print a parsed expression; they are not meant to be constructed by
+hand.
 
 .. automodule:: formulate.AST
    :members:
-   :undoc-members:
    :show-inheritance:
+   :member-order: bysource

--- a/docs/api/modules/exceptions.rst
+++ b/docs/api/modules/exceptions.rst
@@ -1,9 +1,14 @@
 Exceptions
 =======================================
 
-This module provides functions for handling exceptions.
+Parse failures, and the helpers that attach suggestions to them.
+
+:class:`~formulate.exceptions.ParseError` is re-exported at the top level as
+``formulate.ParseError``, which is how it should normally be caught. Note that
+it covers *syntax* errors only: an expression that parses but uses a construct
+the target language has no equivalent for raises ``ValueError`` when it is
+rendered, not when it is parsed.
 
 .. automodule:: formulate.exceptions
    :members:
-   :undoc-members:
    :show-inheritance:

--- a/docs/api/modules/formulate.rst
+++ b/docs/api/modules/formulate.rst
@@ -1,9 +1,10 @@
 formulate
 ======================
 
-This module provides the main functions for Formulate.
+The top-level module: parsing an expression, and the error raised when that
+fails. Everything you can do with a parsed expression is documented under
+:doc:`ast`.
 
 .. automodule:: formulate
    :members:
-   :undoc-members:
    :show-inheritance:

--- a/docs/api/modules/formulate.rst
+++ b/docs/api/modules/formulate.rst
@@ -7,4 +7,5 @@ fails. Everything you can do with a parsed expression is documented under
 
 .. automodule:: formulate
    :members:
+   :member-order: bysource
    :show-inheritance:

--- a/docs/api/modules/identifiers.rst
+++ b/docs/api/modules/identifiers.rst
@@ -1,9 +1,43 @@
 Identifiers
 =======================================
 
-This module provides definitions for how constants and function translations.
-
 .. automodule:: formulate.identifiers
-   :members:
-   :undoc-members:
-   :show-inheritance:
+
+For the list of what is actually supported, in a form meant for reading, see
+:doc:`../../guide/expressions`. The tables below are the definitions that page
+describes; their contents are not reproduced here, since they are long and the
+guide already lays them out side by side.
+
+.. autodata:: formulate.identifiers.FUNCTIONS
+.. autodata:: formulate.identifiers.CONSTANTS
+.. autodata:: formulate.identifiers.UNARY_OPERATORS
+.. autodata:: formulate.identifiers.BINARY_OPERATORS
+.. autodata:: formulate.identifiers.NAMESPACES
+
+Backend spellings
+---------------------------------------
+
+One map per language, from canonical name to how that language writes it. A
+canonical name missing from a map is not supported by that language, and
+rendering it raises ``ValueError``.
+
+.. autodata:: formulate.identifiers.ROOT_FUNCTIONS
+.. autodata:: formulate.identifiers.NUMEXPR_FUNCTIONS
+.. autodata:: formulate.identifiers.PYTHON_FUNCTIONS
+.. autodata:: formulate.identifiers.ROOT_CONSTANTS
+.. autodata:: formulate.identifiers.NUMEXPR_CONSTANTS
+.. autodata:: formulate.identifiers.PYTHON_CONSTANTS
+.. autodata:: formulate.identifiers.ROOT_OPERATOR_SYMBOLS
+.. autodata:: formulate.identifiers.NUMEXPR_OPERATOR_SYMBOLS
+.. autodata:: formulate.identifiers.PYTHON_OPERATOR_SYMBOLS
+.. autodata:: formulate.identifiers.PYTHON_UNARY_FUNCTIONS
+
+Aliases
+---------------------------------------
+
+Alternative spellings a parser may encounter, mapped onto one canonical name.
+
+.. autodata:: formulate.identifiers.FUNCTION_ALIASES
+.. autodata:: formulate.identifiers.CONSTANTS_ALIASES
+.. autodata:: formulate.identifiers.CONSTANTS_FUNCTION_ALIASES
+.. autodata:: formulate.identifiers.FUNCTION_DISPLAY_NAMES

--- a/docs/api/modules/toast.rst
+++ b/docs/api/modules/toast.rst
@@ -1,9 +1,8 @@
-Tree Operations and AST Transformation
+Parse tree conversion
 =======================================
 
-This module provides utilities for tree operations and AST transformation.
+This module is internal; it is documented because it is where a "no such
+function or constant" error comes from.
 
 .. automodule:: formulate.toast
-   :members:
-   :undoc-members:
-   :show-inheritance:
+   :members: toast

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 # -- Project information -----------------------------------------------------
 
 project = "formulate"
-copyright = "2016-2025, The Scikit-HEP Administrators"
+copyright = "2016-2026, The Scikit-HEP Administrators"
 author = "Chris Burr, Jonas Eschle, Aryan Roy"
 
 
@@ -24,6 +24,7 @@ author = "Chris Burr, Jonas Eschle, Aryan Roy"
 extensions = [
     "myst_parser",
     "sphinx.ext.autodoc",
+    "sphinx.ext.intersphinx",
     "sphinx.ext.mathjax",
     "sphinx.ext.napoleon",
     "sphinx_copybutton",
@@ -60,3 +61,16 @@ myst_enable_extensions = [
     "colon_fence",
     "deflist",
 ]
+
+# The lookup tables in formulate.identifiers are plain dicts and sets with no
+# docstrings of their own; without this, autodoc falls back to documenting each
+# of them with dict.__doc__.
+autodoc_inherit_docstrings = False
+
+# Keep the (long) contents of those tables out of the signature line.
+autodoc_default_options = {"no-value": True}
+
+intersphinx_mapping = {
+    "python": ("https://docs.python.org/3", None),
+    "numpy": ("https://numpy.org/doc/stable", None),
+}

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -67,7 +67,8 @@ myst_enable_extensions = [
 # of them with dict.__doc__.
 autodoc_inherit_docstrings = False
 
-# Keep the (long) contents of those tables out of the signature line.
+# Keep the (long) contents of those tables out of the signature line. Settable
+# from here only since Sphinx 5.0, which is what the docs extra requires.
 autodoc_default_options = {"no-value": True}
 
 intersphinx_mapping = {

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -13,7 +13,7 @@ from __future__ import annotations
 
 project = "formulate"
 copyright = "2016-2026, The Scikit-HEP Administrators"
-author = "Chris Burr, Jonas Eschle, Aryan Roy"
+author = "Chris Burr, Jonas Eschle, Aryan Roy, Andres Rios-Tascon"
 
 
 # -- General configuration ---------------------------------------------------

--- a/docs/contributing/contributing.rst
+++ b/docs/contributing/contributing.rst
@@ -34,8 +34,8 @@ Setting Up Your Development Environment
        pip install -e ".[dev]"
 
    The ``dev`` extra pulls in the test and docs requirements plus ``prek``.
-   Installing only ``.[test]`` is enough to run most of the suite, but leaves
-   out ``numexpr``, which ``tests/test_constants.py`` needs.
+   ``.[test]`` on its own is enough to run the whole suite; ``.[docs]`` on its
+   own is enough to build the documentation.
 
 5. **Set Up Pre-commit Hooks**
 

--- a/docs/contributing/contributing.rst
+++ b/docs/contributing/contributing.rst
@@ -19,13 +19,23 @@ Setting Up Your Development Environment
 
 3. **Set Up a Virtual Environment**
 
-   It's recommended to use a virtual environment for development (e.g., ``venv``, ``conda``, ``uv`` etc.):
+   It's recommended to use a virtual environment for development (e.g.
+   ``venv``, ``conda``, ``uv``, etc.):
+
+   .. code-block:: bash
+
+       python -m venv .venv
+       source .venv/bin/activate   # .venv\Scripts\activate on Windows
 
 4. **Install Development Dependencies**
 
    .. code-block:: bash
 
        pip install -e ".[dev]"
+
+   The ``dev`` extra pulls in the test and docs requirements plus ``prek``.
+   Installing only ``.[test]`` is enough to run most of the suite, but leaves
+   out ``numexpr``, which ``tests/test_constants.py`` needs.
 
 5. **Set Up Pre-commit Hooks**
 
@@ -71,6 +81,17 @@ Development Workflow
 
        pytest
 
+   A few useful variations:
+
+   .. code-block:: bash
+
+       pytest tests/test_root.py            # one file
+       pytest -k tmath_min                  # one test, by name
+       pytest --cov=formulate --cov-branch  # with coverage
+
+   Note that ``tests/test_constants.py`` evaluates expressions with the real
+   engines and skips the ROOT half unless ROOT is importable, which CI only
+   arranges on one job. Everything else runs everywhere.
 
 4. **Commit Your Changes**
 
@@ -93,30 +114,83 @@ Development Workflow
 
    Go to the `Formulate repository <https://github.com/scikit-hep/formulate>`_ and create a pull request from your branch.
 
+Using nox
+----------------------------------------------
+
+`nox <https://nox.thea.codes/>`_ runs each task in its own isolated
+environment, which is what CI does and is the quickest way to reproduce a CI
+failure locally. It needs no setup beyond ``pipx install nox``:
+
+.. code-block:: bash
+
+    nox                       # the default: lint, pylint and tests
+    nox -s tests              # just the tests
+    nox -s coverage           # tests, with coverage measured
+    nox -s lint               # all the pre-commit hooks
+    nox -s docs               # build the documentation
+    nox -s docs -- --serve    # build it and serve it at localhost:8000
+
 Coding Guidelines
 -----------------------------
 
 1. **Code Style**
 
-   Formulate follows the PEP 8 style guide. The hooks installed above will help ensure your code adheres to this style.
+   Formulate follows the PEP 8 style guide, enforced by ``ruff``. The hooks
+   installed above take care of the formatting for you; ``mypy`` also runs over
+   ``src`` in strict mode, so new code needs to be fully typed.
 
 2. **Documentation**
 
-   - Document all public functions, classes, and methods using docstrings
-   - Use type hints where appropriate
-   - Update the documentation if you add new features or change existing ones
+   - Document all public functions, classes, and methods using docstrings.
+     They are what the :doc:`../api/api` pages are built from.
+   - Update the narrative documentation when you add or change a feature. In
+     particular, ``docs/guide/expressions.rst`` lists every supported function
+     and constant, and ``docs/guide/issues.rst`` is the reference for the
+     places where the languages disagree — both should stay in step with the
+     code.
+   - Examples in the docs are executed when the docs are built, so an example
+     that has gone stale will show up as a failed build rather than as wrong
+     output on the website.
 
 3. **Testing**
 
    - Write tests for all new features and bug fixes
-   - Ensure all tests pass before submitting a pull request
-   - Aim for high test coverage
+   - Coverage is enforced at 100% for both the project and the diff, so a new
+     branch needs a test that reaches it. Genuinely unreachable code is marked
+     ``# pragma: no cover``; if a branch cannot be reached, consider whether it
+     should exist at all.
+   - Warnings are errors in the test suite, so anything that starts warning
+     will fail
 
 4. **Commit Messages**
 
    - Write clear, concise commit messages
    - Start with a short summary line (50 chars or less)
    - Optionally, follow with a blank line and a more detailed explanation
+
+Adding a function or a constant
+------------------------------------------------
+
+This is the most common kind of contribution, and it is mostly table editing.
+In ``src/formulate/identifiers.py``:
+
+1. Add the canonical name to ``FUNCTIONS`` or ``CONSTANTS``. This name is
+   internal — it is what appears in the AST — so it should not be any one
+   language's spelling. The NumPy-style name is the usual choice.
+2. Add an entry to each backend's map (``ROOT_FUNCTIONS``,
+   ``NUMEXPR_FUNCTIONS``, ``PYTHON_FUNCTIONS``, and the ``*_CONSTANTS``
+   equivalents) for the languages that support it. Leaving it out of a map is
+   how "not supported here" is expressed; the conversion will then raise a
+   clear ``ValueError`` rather than emitting something wrong.
+3. Add any other spellings people might write to ``FUNCTION_ALIASES``,
+   ``CONSTANTS_ALIASES`` or ``CONSTANTS_FUNCTION_ALIASES``.
+
+``tests/test_identifiers.py`` drives every entry in these tables through the
+parser and cross-checks the tables against each other, so a name that is
+declared but not mapped — or mapped but not declared — fails loudly.
+
+Finally, add the new name to the tables in ``docs/guide/expressions.rst``,
+which is where users look for what is supported.
 
 Types of Contributions
 ------------------------------------------------

--- a/docs/guide/expressions.rst
+++ b/docs/guide/expressions.rst
@@ -1,204 +1,667 @@
 Supported Expressions
 ===================================
 
-Formulate supports a wide range of expressions in both ROOT and numexpr formats. This page documents the supported expression types and syntax.
+This page is the reference for what formulate accepts and what it produces: the
+operators of each language, the functions and constants it knows, and the
+handful of constructs it deliberately refuses.
 
-Operators
-----------------
-
-Arithmetic Operators
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-Both ROOT and numexpr support the following arithmetic operators:
-
-.. list-table::
-   :header-rows: 1
-   :widths: 20 40 40
-
-   * - Operator
-     - ROOT Example
-     - numexpr Example
-   * - Addition (+)
-     - ``x + y``
-     - ``x + y``
-   * - Subtraction (-)
-     - ``x - y``
-     - ``x - y``
-   * - Multiplication (*)
-     - ``x * y``
-     - ``x * y``
-   * - Division (/)
-     - ``x / y``
-     - ``x / y``
-   * - Power (**)
-     - ``x**y``, ``x^y``, ``TMath::Power(x, y)``
-     - ``x**y``
-   * - Modulo (%)
-     - ``x % y``
-     - ``x % y``
-
-.. warning::
-
-   ROOT and numexpr disagree about what ``%`` computes, and formulate converts
-   it in either direction without complaint. See :ref:`issues-modulo`.
-
-Comparison Operators
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-.. list-table::
-   :header-rows: 1
-   :widths: 20 40 40
-
-   * - Operator
-     - ROOT Example
-     - numexpr Example
-   * - Equal (==)
-     - ``x == y``
-     - ``x == y``
-   * - Not Equal (!=)
-     - ``x != y``
-     - ``x != y``
-   * - Greater Than (>)
-     - ``x > y``
-     - ``x > y``
-   * - Less Than (<)
-     - ``x < y``
-     - ``x < y``
-   * - Greater Than or Equal (>=)
-     - ``x >= y``
-     - ``x >= y``
-   * - Less Than or Equal (<=)
-     - ``x <= y``
-     - ``x <= y``
-
-Logical Operators
-~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-.. list-table::
-   :header-rows: 1
-   :widths: 20 40 40
-
-   * - Operator
-     - ROOT Example
-     - numexpr Example
-   * - AND
-     - ``x && y``
-     - ``x & y``
-   * - OR
-     - ``x || y``
-     - ``x | y``
-   * - NOT
-     - ``!x``
-     - ``~x``
-
-.. note::
-
-   Each language accepts only its own spelling, and formulate will tell you
-   which one an expression needs. They also bind differently against
-   comparisons; see :ref:`issues-logical-binding`.
-
-Functions
-----------------
-
-Formulate supports many mathematical and utility functions. Here are some commonly used functions:
-
-Mathematical Functions
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-.. list-table::
-   :header-rows: 1
-   :widths: 30 35 35
-
-   * - Function
-     - ROOT Syntax
-     - numexpr Syntax
-   * - Square Root
-     - ``TMath::Sqrt(x)``
-     - ``sqrt(x)``
-   * - Absolute Value
-     - ``TMath::Abs(x)``
-     - ``abs(x)``
-   * - Exponential
-     - ``TMath::Exp(x)``
-     - ``exp(x)``
-   * - Logarithm (natural)
-     - ``TMath::Log(x)``
-     - ``log(x)``
-   * - Logarithm (base 10)
-     - ``TMath::Log10(x)``
-     - ``log10(x)``
-   * - Sine
-     - ``TMath::Sin(x)``
-     - ``sin(x)``
-   * - Cosine
-     - ``TMath::Cos(x)``
-     - ``cos(x)``
-   * - Tangent
-     - ``TMath::Tan(x)``
-     - ``tan(x)``
-   * - Arc Sine
-     - ``TMath::ASin(x)``
-     - ``arcsin(x)``
-   * - Arc Cosine
-     - ``TMath::ACos(x)``
-     - ``arccos(x)``
-   * - Arc Tangent
-     - ``TMath::ATan(x)``
-     - ``arctan(x)``
-   * - Arc Tangent (2 args)
-     - ``TMath::ATan2(y, x)``
-     - ``arctan2(y, x)``
-   * - Hyperbolic Sine
-     - ``TMath::SinH(x)``
-     - ``sinh(x)``
-   * - Hyperbolic Cosine
-     - ``TMath::CosH(x)``
-     - ``cosh(x)``
-   * - Hyperbolic Tangent
-     - ``TMath::TanH(x)``
-     - ``tanh(x)``
-   * - Floor
-     - ``TMath::Floor(x)``
-     - ``floor(x)``
-   * - Ceiling
-     - ``TMath::Ceil(x)``
-     - ``ceil(x)``
-
-
-Complex Expressions
--------------------------------
-
-Formulate can handle complex expressions combining multiple operators and functions:
+Three languages are involved. ROOT and NumExpr can each be both an input and an
+output; Python is output-only, and is rendered with NumPy function names, so it
+is meant to be evaluated somewhere ``numpy`` is imported as ``np``.
 
 .. jupyter-execute::
    :hide-code:
 
-    import formulate
+   import formulate
 
-.. code-block:: python
+Two things are true of every conversion. Output is **fully parenthesized**,
+because the languages disagree about precedence and formulate would rather be
+explicit than clever:
 
-    # ROOT expression
-    root_expr = "TMath::Sqrt(px**2 + py**2 + pz**2) > 10 && TMath::Abs(eta) < 2.5"
+.. jupyter-execute::
 
-    # Equivalent numexpr expression
-    numexpr_expr = "(sqrt(px**2 + py**2 + pz**2) > 10) & (abs(eta) < 2.5)"
+   print(formulate.from_root("a + b * c").to_numexpr())
 
-    # Convert between them
-    from_root = formulate.from_root(root_expr)
-    print(from_root.to_numexpr())  # Outputs the numexpr version
+And a parsed expression is **immutable and reusable** — parse once, render as
+many times as you like:
 
-    from_numexpr = formulate.from_numexpr(numexpr_expr)
-    print(from_numexpr.to_root())  # Outputs the ROOT version
+.. jupyter-execute::
+
+   expr = formulate.from_root("TMath::Sqrt(px**2 + py**2)")
+   print(expr.to_root())
+   print(expr.to_numexpr())
+   print(expr.to_python())
+
+Operators
+----------------
+
+Arithmetic
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. list-table::
+   :header-rows: 1
+   :widths: 25 25 25 25
+
+   * - Operation
+     - ROOT
+     - NumExpr
+     - Python
+   * - Addition
+     - ``x + y``
+     - ``x + y``
+     - ``x + y``
+   * - Subtraction
+     - ``x - y``
+     - ``x - y``
+     - ``x - y``
+   * - Multiplication
+     - ``x * y``
+     - ``x * y``
+     - ``x * y``
+   * - Division
+     - ``x / y``
+     - ``x / y``
+     - ``x / y``
+   * - Power
+     - ``x**y``, ``x^y``, ``TMath::Power(x, y)``
+     - ``x**y``
+     - ``x**y``
+   * - Modulo
+     - ``x % y``
+     - ``x % y``
+     - ``x % y``
+   * - Unary plus / minus
+     - ``+x``, ``-x``
+     - ``+x``, ``-x``
+     - ``+x``, ``-x``
+
+Power is the only operator that groups from the right, in all three languages:
+``a**b**c`` is ``a**(b**c)``.
+
+.. warning::
+
+   ROOT and NumExpr disagree about what ``%`` computes, and formulate converts
+   it in either direction without complaint. It is the one construct that can
+   silently change meaning. See :ref:`issues-modulo`.
+
+Comparisons
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+``==``, ``!=``, ``>``, ``<``, ``>=`` and ``<=`` are spelled the same way in all
+three languages.
+
+NumExpr does not support chained comparisons, so ``a < b < c`` is rejected on
+input; write ``(a < b) & (b < c)``. ROOT accepts chains, because C++ does, but
+they mean ``(a < b) < c`` there rather than what they mean in Python — so they
+are almost always a mistake worth rewriting too.
+
+Logical operators
+~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. list-table::
+   :header-rows: 1
+   :widths: 25 25 25 25
+
+   * - Operation
+     - ROOT
+     - NumExpr
+     - Python
+   * - AND
+     - ``x && y``
+     - ``x & y``
+     - ``x & y``
+   * - OR
+     - ``x || y``
+     - ``x | y``
+     - ``x | y``
+   * - NOT
+     - ``!x``
+     - ``~x``
+     - ``np.logical_not(x)``
+   * - XOR
+     - —
+     - ``x ^ y``
+     - ``x ^ y``
+
+Each parser accepts only its own language's spelling, and tells you which one an
+expression needs if you get it wrong:
+
+.. jupyter-execute::
+
+   try:
+       formulate.from_numexpr("a && b")
+   except formulate.ParseError as error:
+       print(error)
+
+Two differences are worth internalising. The operators **bind differently**
+against comparisons — ROOT's are logical and bind looser, NumExpr's are bitwise
+and bind tighter (see :ref:`issues-logical-binding`) — and **ROOT has no XOR**,
+since it spells exponentiation with ``^``, so a NumExpr expression using XOR
+cannot be converted to ROOT.
+
+Python's NOT is rendered as ``np.logical_not`` rather than ``~`` on purpose:
+ROOT's ``!`` is a logical negation, whereas NumPy's ``~`` is a bitwise
+inversion, and they disagree on anything that is not a boolean (``!5`` is ``0``
+but ``~5`` is ``-6``).
+
+The ROOT multi-output operator
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+``TTreeFormula`` uses ``:`` to separate the several expressions of a
+multi-dimensional draw. formulate parses it, and renders it in Python as the
+comma-separated list that Python reads as a tuple:
+
+.. jupyter-execute::
+
+   print(formulate.from_root("px : py : pz").to_root())
+   print(formulate.from_root("px : py : pz").to_python())
+
+NumExpr evaluates a single expression and has no equivalent, so converting one
+of these raises.
+
+Indexing
+----------------
+
+ROOT indexes with one bracket pair per dimension and Python with a single
+comma-separated pair; formulate translates between the two spellings:
+
+.. jupyter-execute::
+
+   print(formulate.from_root("arr[0]").to_root())
+   print(formulate.from_root("energies[i][j]").to_python())
+
+NumExpr has no indexing at all — arrays are passed in whole, already sliced — so
+an indexed expression cannot be converted to it.
+
+Functions
+----------------
+
+Names are matched case-insensitively and through a table of aliases, so
+``TMath::ATan2(y, x)``, ``atan2(y, x)`` and ``arctan2(y, x)`` all parse to the
+same thing. The aliases are ``ln`` for ``log``, ``power`` for ``pow``, and the
+``asin``/``acos``/``atan``/``atan2``/``asinh``/``acosh``/``atanh`` spellings of
+the inverse trigonometric functions.
+
+A dash below means the language has no faithful equivalent, and converting such
+an expression to it raises ``ValueError`` rather than approximating.
+
+Common functions
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. list-table::
+   :header-rows: 1
+   :widths: 22 26 26 26
+
+   * - Canonical name
+     - ROOT
+     - NumExpr
+     - Python
+   * - ``sqrt``
+     - ``TMath::Sqrt``
+     - ``sqrt``
+     - ``np.sqrt``
+   * - ``abs``
+     - ``TMath::Abs``
+     - ``abs``
+     - ``np.abs``
+   * - ``pow``
+     - ``TMath::Power``
+     - ``**``
+     - ``np.power``
+   * - ``exp``
+     - ``TMath::Exp``
+     - ``exp``
+     - ``np.exp``
+   * - ``log``
+     - ``TMath::Log``
+     - ``log``
+     - ``np.log``
+   * - ``log2``
+     - ``TMath::Log2``
+     - —
+     - —
+   * - ``log10``
+     - ``TMath::Log10``
+     - ``log10``
+     - ``np.log10``
+   * - ``log1p``
+     - —
+     - ``log1p``
+     - ``np.log1p``
+   * - ``expm1``
+     - —
+     - ``expm1``
+     - ``np.expm1``
+   * - ``sin``
+     - ``TMath::Sin``
+     - ``sin``
+     - ``np.sin``
+   * - ``cos``
+     - ``TMath::Cos``
+     - ``cos``
+     - ``np.cos``
+   * - ``tan``
+     - ``TMath::Tan``
+     - ``tan``
+     - ``np.tan``
+   * - ``arcsin``
+     - ``TMath::ASin``
+     - ``arcsin``
+     - ``np.arcsin``
+   * - ``arccos``
+     - ``TMath::ACos``
+     - ``arccos``
+     - ``np.arccos``
+   * - ``arctan``
+     - ``TMath::ATan``
+     - ``arctan``
+     - ``np.arctan``
+   * - ``arctan2``
+     - ``TMath::ATan2``
+     - ``arctan2``
+     - ``np.arctan2``
+   * - ``sinh``
+     - ``TMath::SinH``
+     - ``sinh``
+     - ``np.sinh``
+   * - ``cosh``
+     - ``TMath::CosH``
+     - ``cosh``
+     - ``np.cosh``
+   * - ``tanh``
+     - ``TMath::TanH``
+     - ``tanh``
+     - ``np.tanh``
+   * - ``arcsinh``
+     - ``TMath::ASinH``
+     - ``arcsinh``
+     - ``np.arcsinh``
+   * - ``arccosh``
+     - ``TMath::ACosH``
+     - ``arccosh``
+     - ``np.arccosh``
+   * - ``arctanh``
+     - ``TMath::ATanH``
+     - ``arctanh``
+     - ``np.arctanh``
+   * - ``ceil``
+     - ``TMath::Ceil``
+     - ``ceil``
+     - ``np.ceil``
+   * - ``floor``
+     - ``TMath::Floor``
+     - ``floor``
+     - ``np.floor``
+
+``pow`` has no function spelling in NumExpr, where it is written as the ``**``
+operator; ``TMath::Power(x, y)`` therefore converts to ``(x ** y)``, and a
+``pow`` call with any other number of arguments has nothing to convert to.
+
+Array reductions
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+These take one array and return a scalar. ROOT spells them with a trailing
+``$``.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 22 26 26 26
+
+   * - Canonical name
+     - ROOT
+     - NumExpr
+     - Python
+   * - ``sum``
+     - ``Sum$``
+     - ``sum``
+     - ``np.sum``
+   * - ``prod``
+     - —
+     - ``prod``
+     - ``np.prod``
+   * - ``min``
+     - ``Min$``
+     - ``min``
+     - ``np.min``
+   * - ``max``
+     - ``Max$``
+     - ``max``
+     - ``np.max``
+   * - ``length``
+     - ``Length$``
+     - —
+     - —
+
+Element-wise minimum and maximum
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+``TMath::Min`` and ``TMath::Max`` take *two* arguments and compare them
+element-wise, which is a different operation from the reductions above. They are
+tracked separately so that ``Min$(arr)`` and ``TMath::Min(a, b)`` do not collide.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 22 26 26 26
+
+   * - Canonical name
+     - ROOT
+     - NumExpr
+     - Python
+   * - ``tmath_min``
+     - ``TMath::Min``
+     - —
+     - ``np.minimum``
+   * - ``tmath_max``
+     - ``TMath::Max``
+     - —
+     - ``np.maximum``
+
+NumExpr's ``min`` and ``max`` are the reductions, not these, so there is nothing
+to convert them to; the equivalent would be ``where(a < b, a, b)``, which is an
+expression rather than a function name:
+
+.. jupyter-execute::
+
+   try:
+       formulate.from_root("TMath::Min(a, b)").to_numexpr()
+   except ValueError as error:
+       print(error)
+
+NumExpr-specific functions
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. list-table::
+   :header-rows: 1
+   :widths: 22 26 26 26
+
+   * - Canonical name
+     - ROOT
+     - NumExpr
+     - Python
+   * - ``where``
+     - —
+     - ``where``
+     - ``np.where``
+   * - ``conj``
+     - —
+     - ``conj``
+     - ``np.conj``
+   * - ``real``
+     - —
+     - ``real``
+     - ``np.real``
+   * - ``imag``
+     - —
+     - ``imag``
+     - ``np.imag``
+   * - ``complex``
+     - —
+     - ``complex``
+     - ``np.complex128``
+   * - ``contains``
+     - —
+     - ``contains``
+     - —
+
+``contains`` is a substring test, and NumPy has no equivalent that can be
+written as a single function name, so it converts to neither of the other two.
+
+ROOT-specific functions
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The rest of ``TMath`` that formulate knows about. None of these have NumExpr or
+NumPy equivalents, so they can only be converted back to ROOT — but they parse,
+which is what makes :attr:`~formulate.AST.AST.variables` usable on any ROOT
+expression.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 30 70
+
+   * - Arguments
+     - ``TMath`` functions
+   * - One
+     - ``BesselI0``, ``BesselI1``, ``BesselJ0``, ``BesselJ1``, ``BesselY0``,
+       ``BesselY1``, ``CeilNint``, ``DiLog``, ``Erf``, ``Erfc``,
+       ``ErfInverse``, ``ErfcInverse``, ``Even``, ``Factorial``,
+       ``FloorNint``, ``Freq``, ``KolmogorovProb``, ``LandauI``, ``LnGamma``,
+       ``NextPrime``, ``NormQuantile``, ``Odd``, ``StruveH0``, ``StruveH1``,
+       ``StruveL0``, ``StruveL1``
+   * - Two
+     - ``BesselI``, ``BesselK``, ``Beta``, ``Binomial``,
+       ``ChisquareQuantile``, ``Ldexp``, ``Permute``, ``Poisson``,
+       ``PoissonI``, ``Prob``, ``Student``, ``StudentI``
+   * - Three
+     - ``AreEqualAbs``, ``AreEqualRel``, ``BetaCf``, ``BetaDist``,
+       ``BetaDistI``, ``BetaIncomplete``, ``BinomialI``, ``BubbleHigh``,
+       ``BubbleLow``, ``FDist``, ``FDistI``, ``Vavilov``, ``VavilovI``
+   * - Four or more
+     - ``Gaus``, ``RootsCubic``, ``Quantiles``
+
+.. note::
+
+   formulate does not check how many arguments a function is given — the tables
+   above record what ROOT's signatures are, but ``TMath::Erf(a, b)`` will parse
+   and convert. The one exception is ``pow`` converted to NumExpr, because the
+   ``**`` operator it becomes has nowhere to put a third argument.
+
+Constants
+----------------
+
+Constants are recognised by name, and in ROOT also in their ``TMath::X()`` call
+form. They are stored canonically, so ``TMath::E()``, ``e_num`` and ``ℯ`` are
+the same constant and all report as ``exp1``.
+
+NumExpr has no symbolic constants, so converting to it — and to Python, for the
+numeric ones — substitutes the value. This is a one-way street: see
+:ref:`issues-constants-round-trip`.
+
+Mathematical constants
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. list-table::
+   :header-rows: 1
+   :widths: 18 26 28 28
+
+   * - Canonical name
+     - Also accepted as
+     - ROOT
+     - NumExpr and Python
+   * - ``pi``
+     - ``π``
+     - ``TMath::Pi()``
+     - ``3.141592653589793``
+   * - ``tau``
+     - ``twopi``, ``τ``
+     - ``TMath::TwoPi()``
+     - ``6.283185307179586``
+   * - ``invpi``
+     - ``oneoverpi``
+     - ``TMath::InvPi()``
+     - ``0.3183098861837907``
+   * - ``piover2``
+     - —
+     - ``TMath::PiOver2()``
+     - ``1.5707963267948966``
+   * - ``piover4``
+     - —
+     - ``TMath::PiOver4()``
+     - ``0.7853981633974483``
+   * - ``exp1``
+     - ``e``, ``e_num``, ``e_number``, ``e_euler``, ``ℯ``
+     - ``TMath::E()``
+     - ``2.718281828459045``
+   * - ``sqrt2``
+     - —
+     - ``TMath::Sqrt2()``
+     - ``1.4142135623730951``
+   * - ``ln10``
+     - —
+     - ``TMath::Ln10()``
+     - ``2.302585092994046``
+   * - ``log10e``
+     - ``loge``
+     - ``TMath::LogE()``
+     - ``0.4342944819032518``
+   * - ``deg2rad``
+     - ``degtorad``
+     - ``TMath::DegToRad()``
+     - ``0.017453292519943295``
+   * - ``rad2deg``
+     - ``radtodeg``
+     - ``TMath::RadToDeg()``
+     - ``57.29577951308232``
+
+Physical constants
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Values come from :mod:`hepunits`, in SI units, matching what ``TMath`` returns.
+
+.. list-table::
+   :header-rows: 1
+   :widths: 18 22 24 20 16
+
+   * - Canonical name
+     - Also accepted as
+     - ROOT
+     - NumExpr and Python
+     - Unit
+   * - ``c_light``
+     - ``clight``, ``c()``
+     - ``TMath::C()``
+     - ``299792458.0``
+     - m/s
+   * - ``h_planck``
+     - ``hplanck``, ``h()``
+     - ``TMath::H()``
+     - ``6.626070149999999e-34``
+     - J·s
+   * - ``hbar``
+     - ``h_bar``, ``ℏ``
+     - ``TMath::Hbar()``
+     - ``1.0545718176461563e-34``
+     - J·s
+   * - ``hbarc``
+     - ``h_bar_c``, ``ℏc``
+     - ``(TMath::Hbar() * TMath::C())``
+     - ``3.16152677349669e-26``
+     - J·m
+   * - ``k_boltzmann``
+     - ``kboltzmann``, ``k()``
+     - ``TMath::K()``
+     - ``1.380649e-23``
+     - J/K
+   * - ``avogadro``
+     - ``na()``
+     - ``TMath::Na()``
+     - ``6.02214076e+23``
+     - 1/mol
+   * - ``eplus``
+     - ``e_plus``, ``qe()``
+     - ``TMath::Qe()``
+     - ``1.602176634e-19``
+     - C
+   * - ``eminus``
+     - ``e_minus``
+     - ``-TMath::Qe()``
+     - ``-1.602176634e-19``
+     - C
+
+.. note::
+
+   The single-letter forms — ``e``, ``c``, ``h``, ``k``, ``na``, ``qe`` — are
+   recognised only in their call form, ``c()`` or ``TMath::C()``. A bare ``c``
+   is a variable, which is what you want when ``c`` is a branch name. This
+   changed in v1.0.1; expressions written for older versions that relied on a
+   bare ``c`` meaning the speed of light need ``c_light``.
+
+Booleans and special values
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+.. list-table::
+   :header-rows: 1
+   :widths: 20 20 20 20 20
+
+   * - Canonical name
+     - Also accepted as
+     - ROOT
+     - NumExpr
+     - Python
+   * - ``true``
+     - ``True``
+     - ``true``
+     - ``True``
+     - ``True``
+   * - ``false``
+     - ``False``
+     - ``false``
+     - ``False``
+     - ``False``
+   * - ``inf``
+     - ``infinity``
+     - ``TMath::Infinity()``
+     - —
+     - ``float('inf')``
+   * - ``neginf``
+     - ``negative_infinity``
+     - ``-TMath::Infinity()``
+     - —
+     - ``float('-inf')``
+   * - ``nan``
+     - ``quietnan``, ``signalingnan``
+     - ``TMath::QuietNaN()``
+     - —
+     - ``float('nan')``
+
+NumExpr has no literal for the non-finite values, so those three cannot be
+converted to it.
+
+Inspecting an expression
+--------------------------------------
+
+Beyond conversion, a parsed expression reports what it refers to. This is what
+you want when deciding which branches to read from a file:
+
+.. jupyter-execute::
+
+   expr = formulate.from_root("TMath::Sqrt(px**2 + py**2) > 5 * TMath::Pi() + 1.5")
+   print(list(expr.variables))
+   print(list(expr.named_constants))
+   print(list(expr.unnamed_constants))
+
+Names come out in the order they first appear, and each is reported once.
+``str()`` on the expression shows the parsed structure in canonical names, which
+is the quickest way to check how something was grouped:
+
+.. jupyter-execute::
+
+   print(formulate.from_root("a && b < c"))
+   print(formulate.from_numexpr("a & b < c"))
 
 Limitations
 -----------------------
 
-While Formulate supports a wide range of expressions, there are some limitations:
+Anything with no faithful equivalent in the target language raises
+``ValueError`` rather than converting to something subtly different — the
+dashes throughout this page are all instances of that. The :doc:`issues` page
+covers the cases people hit most.
 
-1. **Function Support**: Not all functions available in ROOT or numexpr are supported for conversion. If you encounter an unsupported function, please check the API documentation or consider contributing to add support.
+Beyond those:
 
-2. **Complex Data Types**: Formulate primarily focuses on scalar operations. Operations on complex data types like arrays may have limited support.
+1. **Not every function is known.** The tables above are hand-maintained, and a
+   name that is not in them raises rather than being passed through, so that a
+   typo does not become a mysterious failure in the target engine. If something
+   is missing, please open an issue — or add it: a function is one entry per
+   table, and :doc:`../contributing/contributing` describes how.
 
-3. **Custom Functions**: User-defined functions are not automatically supported for conversion.
+2. **User-defined functions are not supported**, for the same reason.
 
-For more details on specific limitations or to request support for additional expressions, please refer to the :doc:`issues` page or open an issue on the GitHub repository.
+3. **Argument counts are not validated**, except for ``pow``.
+
+4. **Strings are not supported.** NumExpr's ``contains`` takes them, but
+   formulate's grammars only accept numbers, names and operators, so an
+   expression containing a string literal will not parse.
+
+5. **Types are not tracked.** formulate translates syntax; whether a branch is
+   an integer or a float, a scalar or an array, is something only the target
+   engine knows. This is what makes ``%`` dangerous — see :ref:`issues-modulo`.

--- a/docs/guide/issues.rst
+++ b/docs/guide/issues.rst
@@ -128,6 +128,8 @@ This is why ``a < b & c < d`` is rejected in numexpr: ``&`` binds tighter, so
 it parses as the chained comparison ``a < (b & c) < d``, which is not
 supported. Write ``(a < b) & (c < d)`` instead.
 
+.. _issues-constants-round-trip:
+
 Named constants do not survive a round trip through numexpr
 ---------------------------------------------------------------------------
 

--- a/docs/guide/speed.rst
+++ b/docs/guide/speed.rst
@@ -1,4 +1,78 @@
 Performance Considerations
 ================================================
 
-TODO
+formulate is a translator, not an evaluator. It runs once, on a string, before
+any data is touched; the work of evaluating the expression belongs to ROOT,
+NumExpr or NumPy afterwards. So the only performance question formulate raises
+is whether translating is cheap enough to ignore, and for the expressions people
+actually write it is: parsing takes on the order of a hundred microseconds, and
+rendering an already-parsed expression an order of magnitude less than that.
+
+That said, a few things are worth knowing if you convert expressions in a loop.
+
+Parse once, render many times
+------------------------------------------------
+
+Parsing is by far the more expensive half, and the result is immutable, so an
+expression you convert to several backends — or convert once and also inspect —
+should be parsed once and kept:
+
+.. jupyter-execute::
+
+   import formulate
+
+   expr = formulate.from_root("TMath::Sqrt(px**2 + py**2) > 10")
+
+   selection = expr.to_numexpr()
+   branches = list(expr.variables)
+
+   print(selection, branches)
+
+If the same expression string comes up repeatedly — one per event loop
+iteration, say — cache the parsed object rather than the string;
+``functools.lru_cache`` over a function that calls
+:func:`~formulate.from_root` is enough.
+
+The grammars are compiled lazily, once
+------------------------------------------------
+
+Each backend's grammar is compiled into an LALR parser the first time that
+backend is used, and then reused for the rest of the process. The first
+:func:`~formulate.from_root` in a session therefore costs a few tens of
+milliseconds more than the ones after it, and a program that only ever parses
+NumExpr never pays for the ROOT grammar at all.
+
+This also means the cost is per process. There is nothing to warm up and
+nothing to persist.
+
+Expression size
+------------------------------------------------
+
+Cost grows linearly with the size of the expression, and nothing in formulate
+recurses — both the parse-tree conversion and the serializers walk the tree with
+an explicit stack — so deeply nested expressions are bounded by memory rather
+than by Python's recursion limit. An expression a thousand parentheses deep
+converts without special handling.
+
+Output is fully parenthesized, so a converted expression is longer than what you
+fed in. It does not keep growing, though: re-parsing adds parse-tree depth but
+not AST nodes, so converting a converted expression gives the same string back.
+
+.. jupyter-execute::
+
+   once = formulate.from_root("a + b * c").to_root()
+   twice = formulate.from_root(once).to_root()
+   print(once, twice, once == twice, sep="\n")
+
+That fixed point is what makes the serialized string a canonical form, and it is
+what most of the test suite compares against.
+
+What formulate does *not* affect
+------------------------------------------------
+
+How fast the converted expression evaluates is entirely up to the target engine.
+formulate does not reorder, simplify, or constant-fold anything — ``2 + 2``
+converts to ``(2 + 2)``, not ``4`` — because its job is to preserve meaning, and
+every engine here does its own optimisation anyway. The one thing it changes is
+that named constants become literals when converting to NumExpr, which is a
+consequence of NumExpr having no symbolic constants rather than an optimisation.

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -6,8 +6,18 @@ Welcome to Formulate's documentation!
    :target: https://scikit-hep.org/
 
 Formulate is a Python library for easy conversions between different styles of expressions.
-It currently supports converting between `ROOT <https://root.cern.ch/doc/master/classTFormula.html>`_ and
-`numexpr <https://numexpr.readthedocs.io/en/latest/user_guide.html>`_ style expressions.
+It converts in either direction between `ROOT <https://root.cern.ch/doc/master/classTFormula.html>`_
+(``TTreeFormula``) and `numexpr <https://numexpr.readthedocs.io/en/latest/user_guide.html>`_
+syntax, and can also render any parsed expression as plain Python using NumPy functions.
+
+.. code-block:: pycon
+
+   >>> import formulate
+   >>> formulate.from_root("TMath::Sqrt(px**2 + py**2) > 10").to_numexpr()
+   '(sqrt(((px ** 2) + (py ** 2))) > 10)'
+
+Install it with ``pip install formulate`` or ``conda install -c conda-forge formulate``,
+then start with the :doc:`quickstart/introduction`.
 
 .. toctree::
    :maxdepth: 2

--- a/docs/project/citations.rst
+++ b/docs/project/citations.rst
@@ -21,7 +21,7 @@ version you used. You can get that from the package:
 
     @software{formulate,
       author  = {Burr, Chris and Roy, Aryan and Eschle, Jonas and
-                 {The Scikit-HEP admins}},
+                 Rios-Tascon, Andres and {The Scikit-HEP admins}},
       title   = {formulate: easy conversions between different styles of expressions},
       url     = {https://github.com/scikit-hep/formulate},
       version = {1.0.1},

--- a/docs/project/citations.rst
+++ b/docs/project/citations.rst
@@ -1,10 +1,73 @@
 Citing Formulate
 ======================
 
-If you use Formulate in your research, please cite it appropriately. This page provides information on how to cite Formulate in academic work.
+If formulate was useful in work you are publishing, please cite it. There are
+two things worth citing: the package itself, and the Scikit-HEP project it
+belongs to.
 
-Citation Information
+Citing the package
 ----------------------------------------------
 
+formulate does not yet have its own DOI, so cite it as software, giving the
+version you used. You can get that from the package:
 
-TODO
+.. jupyter-execute::
+
+    import formulate
+
+    print(formulate.__version__)
+
+.. code-block:: bibtex
+
+    @software{formulate,
+      author  = {Burr, Chris and Roy, Aryan and Eschle, Jonas and
+                 {The Scikit-HEP admins}},
+      title   = {formulate: easy conversions between different styles of expressions},
+      url     = {https://github.com/scikit-hep/formulate},
+      version = {1.0.1},
+      year    = {2025},
+    }
+
+Replace ``version`` and ``year`` with the ones you actually used — conversions
+and constant names have changed between releases, so the version is the part
+that makes the citation reproducible. The :doc:`../quickstart/whatsnew` page
+records what changed when.
+
+Citing Scikit-HEP
+----------------------------------------------
+
+formulate is part of `Scikit-HEP <https://scikit-hep.org/>`_. If you are citing
+the ecosystem as a whole, or several of its packages, the project paper is the
+reference to use:
+
+    E. Rodrigues et al., *The Scikit-HEP Project — overview and prospects*,
+    EPJ Web Conf. **245**, 06028 (2020),
+    `doi:10.1051/epjconf/202024506028 <https://doi.org/10.1051/epjconf/202024506028>`_,
+    `arXiv:2007.03577 <https://arxiv.org/abs/2007.03577>`_.
+
+.. code-block:: bibtex
+
+    @article{scikit-hep,
+      author    = {Rodrigues, Eduardo and others},
+      title     = {The Scikit HEP Project -- overview and prospects},
+      journal   = {EPJ Web Conf.},
+      volume    = {245},
+      pages     = {06028},
+      year      = {2020},
+      doi       = {10.1051/epjconf/202024506028},
+      eprint    = {2007.03577},
+      archivePrefix = {arXiv},
+    }
+
+The Scikit-HEP `citation page <https://scikit-hep.org/citing>`_ has the
+up-to-date version of this, and covers the other packages in the project.
+
+Citing what formulate converts *to*
+----------------------------------------------
+
+formulate translates expressions; the evaluation is done by something else. If
+the analysis you are describing leaned on that engine's behaviour, cite it as
+well — `ROOT <https://root.cern/>`_ or
+`NumExpr <https://numexpr.readthedocs.io/>`_ as appropriate, and
+`NumPy <https://numpy.org/citing-numpy/>`_ for :meth:`~formulate.AST.AST.to_python`
+output.

--- a/docs/project/contact.rst
+++ b/docs/project/contact.rst
@@ -18,6 +18,7 @@ Formulate is maintained by:
 * **Chris Burr** — original author
 * **Jonas Eschle** — core developer
 * **Aryan Roy** — core developer
+* **Andres Rios-Tascon** — core developer
 * **The Scikit-HEP admins**, who maintain the package as part of the project
 
 Everyone who has contributed is listed on the `contributors page

--- a/docs/project/contact.rst
+++ b/docs/project/contact.rst
@@ -15,10 +15,13 @@ Maintainers
 
 Formulate is maintained by:
 
-* **Chris Burr** - Original author
-* **Jonas Eschle** - Core developer
-* **Aryan Roy** - Core developer
-* **The Scikit-HEP Contributors** - A community of developers contributing to the Scikit-HEP ecosystem
+* **Chris Burr** — original author
+* **Jonas Eschle** — core developer
+* **Aryan Roy** — core developer
+* **The Scikit-HEP admins**, who maintain the package as part of the project
+
+Everyone who has contributed is listed on the `contributors page
+<https://github.com/scikit-hep/formulate/graphs/contributors>`_.
 
 Getting in Touch
 ----------------------------
@@ -32,8 +35,8 @@ GitHub
 * **Discussions**: For questions, ideas, and general discussion, use `GitHub Discussions <https://github.com/scikit-hep/formulate/discussions>`_.
 * **Pull Requests**: For code contributions, submit a pull request on GitHub. See the :doc:`../contributing/contributing` page for guidelines.
 
-
-
+If you are unsure which of these fits, :doc:`../questions/questions` describes
+what belongs where.
 
 Contributing
 ------------------------

--- a/docs/questions/questions.rst
+++ b/docs/questions/questions.rst
@@ -26,19 +26,14 @@ For bug reports or specific technical issues:
 * If not, create a `new issue <https://github.com/scikit-hep/formulate/issues/new>`_ with details about your problem
 * Include information about your environment, steps to reproduce, and any error messages
 
-Stack Overflow
+Elsewhere in Scikit-HEP
 ~~~~~~~~~~~~~~~~~~~~~~~
 
-For questions that might be relevant to a broader audience:
-
-* Ask on Stack Overflow with the `formulate <https://stackoverflow.com/questions/tagged/formulate>`_ tag
-* Also consider adding related tags like ``python``, ``root``, or ``numexpr`` depending on your question
-* Follow Stack Overflow's guidelines for asking good questions:
-  - Be specific
-  - Include minimal, reproducible examples
-  - Show what you've tried so far
-
-
+If your question is really about the tool at the other end of the conversion —
+how ``TTreeFormula`` evaluates something, or what numexpr does with a
+particular dtype — that project's own issue tracker will get you a better
+answer. The `Scikit-HEP <https://scikit-hep.org/>`_ website lists the packages
+in the ecosystem and where each is discussed.
 
 How to Ask Effective Questions
 ------------------------------------------------------------------------------------------------------------------------------------------
@@ -60,23 +55,37 @@ To get the best help possible, consider these tips when asking questions:
 
 3. **Show Minimal Examples**
 
-   Include the smallest possible code example that demonstrates your issue:
+   Include the smallest possible code example that demonstrates your issue —
+   the expression that fails, and what you expected instead:
 
    .. jupyter-execute::
 
        import formulate
 
-       # This works
-       expr1 = formulate.from_root("x + y")
-       print(expr1.to_numexpr())  # Outputs: "x + y"
+       # This converts fine
+       print(formulate.from_root("x + y").to_numexpr())
 
-       # This doesn't work
-       expr2 = formulate.from_root("problematic_expression")
-       print(expr2.to_numexpr())  # Error occurs here
+       # This does not, and here is what it says
+       try:
+           formulate.from_root("arr[0]").to_numexpr()
+       except ValueError as error:
+           print(error)
+
+   Reducing a long expression to the part that misbehaves is usually the step
+   that answers the question by itself.
 
 4. **Include Full Error Messages**
 
-   If you're encountering an error, include the complete error message with traceback.
+   If you're encountering an error, include the complete error message with
+   traceback. Formulate's parse errors carry a location and often a
+   suggestion, and both are useful:
+
+   .. jupyter-execute::
+
+       try:
+           formulate.from_root("a & b")
+       except formulate.ParseError as error:
+           print(error)
 
 5. **Describe What You've Tried**
 

--- a/docs/quickstart/example.rst
+++ b/docs/quickstart/example.rst
@@ -1,102 +1,130 @@
 Simple Example
 =====================
 
-This page provides a quick example of how to use Formulate to convert between different expression formats.
+This page walks through the whole of Formulate's interface on one small example.
+Every output below is produced by running the code shown, so it is what you will
+get too.
 
 Basic Usage
 ------------------------
 
-The most basic usage involves calling ``from_$BACKEND`` and then ``to_$BACKEND``, where ``$BACKEND`` is the format you're converting from or to.
+The library has two entry points, ``from_root`` and ``from_numexpr``. Each
+parses a string and returns an expression object, which then knows how to render
+itself in any of the supported styles.
 
 Converting from ROOT to numexpr
---------------------------------------------------------------------------------------------------------------------------------------------
-
-Here's an example of converting a ROOT expression to numexpr:
+--------------------------------------------------
 
 .. jupyter-execute::
-    :hide-code:
 
     import formulate
 
-.. code-block:: python
-
-    import formulate
-
-    # Create an expression object from a ROOT expression
     momentum = formulate.from_root("TMath::Sqrt(X_PX**2 + X_PY**2 + X_PZ**2)")
 
-    # Convert to numexpr format
-    numexpr_expression = momentum.to_numexpr()
-    print(numexpr_expression)
-    # Output: "sqrt((((X_PX ** 2) + (X_PY ** 2)) + (X_PZ ** 2)))"
+    print(momentum.to_numexpr())
 
-    # You can also convert back to ROOT format
-    root_expression = momentum.to_root()
-    print(root_expression)
-    # Output: "TMath::Sqrt((((X_PX ** 2) + (X_PY ** 2)) + (X_PZ ** 2)))"
+Nothing about the object remembers where it came from, so it converts back just
+as happily:
+
+.. jupyter-execute::
+
+    print(momentum.to_root())
+
+Note that the output is fully parenthesized. Formulate does not try to reproduce
+your spacing or drop redundant brackets — the three languages disagree about
+precedence, and being explicit is how a conversion stays correct.
 
 Converting from numexpr to ROOT
---------------------------------------------------------------------------------------------------------------------------------------------
+--------------------------------------------------
 
-Similarly, you can convert from numexpr to ROOT:
+The same in the other direction:
 
-.. code-block:: python
+.. jupyter-execute::
 
-    import formulate
-
-    # Create an expression object from a numexpr expression
     selection = formulate.from_numexpr("(X_PT > 5) & ((Mu_NHits > 3) | (Mu_PT > 10))")
 
-    # Convert to ROOT format
-    root_expression = selection.to_root()
-    print(root_expression)
-    # Output: "(X_PT > 5) && ((Mu_NHits > 3) || (Mu_PT > 10)))"
+    print(selection.to_root())
+    print(selection.to_numexpr())
 
-    # You can also convert back to numexpr format
-    numexpr_expression = selection.to_numexpr()
-    print(numexpr_expression)
-    # Output: "((X_PT > 5) & ((Mu_NHits > 3) | (Mu_PT > 10)))"
+Converting to Python
+--------------------------------------------------
+
+There is a third output style: plain Python, using NumPy for the functions.
+There is no ``from_python`` — this direction is output-only.
+
+.. jupyter-execute::
+
+    print(momentum.to_python())
+
+Function names come out prefixed with ``np.``, so the result is meant to be
+evaluated somewhere ``numpy`` has been imported as ``np``.
+
+Inspecting an expression
+--------------------------------------------------
+
+An expression also reports what it refers to, which is how you find out what to
+read from a file before you read it:
+
+.. jupyter-execute::
+
+    expr = formulate.from_root("TMath::Sqrt(px**2 + py**2) > 5 * TMath::Pi() + 1.5")
+
+    print(list(expr.variables))
+    print(list(expr.named_constants))
+    print(list(expr.unnamed_constants))
 
 Using the Converted Expressions
--------------------------------------------------------------------------------------------------------------------------------------------
+--------------------------------------------------
 
-Once you have converted an expression, you can use it with the appropriate backend:
-
+Once converted, an expression is just a string that the target engine accepts.
 With numexpr:
 
 .. jupyter-execute::
 
     import numpy as np
     import numexpr as ne
-    import formulate
 
-    # Create some sample data
     data = {
         "X_PT": np.array([3, 6, 9, 12]),
         "Mu_NHits": np.array([2, 4, 1, 5]),
         "Mu_PT": np.array([8, 5, 12, 7]),
     }
 
-    # Use the converted numexpr expression
-    selection = formulate.from_numexpr("(X_PT > 5) & ((Mu_NHits > 3) | (Mu_PT > 10))")
-    result = ne.evaluate(selection.to_numexpr(), local_dict=data)
-    print(result)
-    # Output: [False  True  True  True]
+    print(ne.evaluate(selection.to_numexpr(), local_dict=data))
 
-With ROOT (pseudo-code, as actual implementation depends on your ROOT setup):
+The Python output can be handed to ``eval`` in the same way:
+
+.. jupyter-execute::
+
+    print(eval(selection.to_python(), {"np": np}, data))
+
+With ROOT, the converted string goes wherever a ``TTreeFormula`` would:
 
 .. code-block:: python
 
-    # Assuming you have a ROOT TTree with branches X_PT, Mu_NHits, and Mu_PT
+    # Assuming a TTree with branches X_PT, Mu_NHits and Mu_PT
     tree.Draw(">>eventList", selection.to_root())
 
-    # Now you can use the eventList to process selected events
-    # ...
+When a conversion is not possible
+--------------------------------------------------
+
+Not everything has an equivalent everywhere. Rather than emit something that
+looks right and computes something else, Formulate raises:
+
+.. jupyter-execute::
+
+    try:
+        formulate.from_root("TMath::Infinity()").to_numexpr()
+    except ValueError as error:
+        print(error)
+
+The :doc:`../guide/issues` page lists the cases worth knowing about in advance.
 
 CLI Usage
---------------------------------------------------------------
+--------------------------------------------------
 
-The package also provides a command-line interface for converting expressions between different styles. To use it, simply run the ``formulate`` command followed by the input expression and the desired output.
+The same conversions are available from the shell. One option says what to
+parse, one says what to print:
 
 .. code-block:: bash
 
@@ -105,6 +133,14 @@ The package also provides a command-line interface for converting expressions be
 
     $ formulate --from-numexpr '(A & B) | sqrt(A)' --to-root
     ((A && B) || TMath::Sqrt(A))
+
+    $ formulate --from-root 'TMath::Sqrt(A)' --to-python
+    np.sqrt(A)
+
+The introspection properties have flags too, printing one name per line so the
+output can be piped into something else:
+
+.. code-block:: bash
 
     $ formulate --from-root '(A && B) || TMath::Sqrt(1.23) * e_num**1.2 + 5*pi' --variables
     A
@@ -118,3 +154,5 @@ The package also provides a command-line interface for converting expressions be
     1.23
     1.2
     5
+
+Run ``formulate --help`` for the full list.

--- a/docs/quickstart/installation.rst
+++ b/docs/quickstart/installation.rst
@@ -1,12 +1,16 @@
 Installation
 ===================
 
-Formulate can be installed using pip, conda, or by building from source.
+Formulate needs Python 3.10 or newer, and can be installed with pip, with
+conda, or from source. It is a pure-Python package with three small
+dependencies (``lark``, ``hepunits`` and ``ordered-set``); notably, it does
+**not** require ROOT or NumExpr, since it only reads and writes their syntax.
 
 Using pip
 ------------------------
 
-The recommended way to install Formulate is using pip:
+The recommended way to install Formulate is using pip, ideally inside a virtual
+environment:
 
 .. code-block:: bash
 
@@ -21,11 +25,14 @@ For development or to get the latest unreleased changes, you can install directl
 Using conda
 ------------------------
 
-Formulate is also available on conda-forge (TODO: not yet:
+Formulate is also available on conda-forge:
 
 .. code-block:: bash
 
     conda install -c conda-forge formulate
+
+The ``-c conda-forge`` is only needed if you do not already have the
+conda-forge channel configured.
 
 From Source
 ------------------------
@@ -45,6 +52,9 @@ To install Formulate from source:
 
        pip install -e .
 
+   Add the ``dev`` extra — ``pip install -e ".[dev]"`` — if you intend to run
+   the tests, the linters or the docs build. See
+   :doc:`../contributing/contributing` for what that gets you.
 
 Verifying Installation
 ------------------------------------------------
@@ -56,3 +66,9 @@ To verify that Formulate is installed correctly, you can run:
     import formulate
 
     print(formulate.__version__)
+
+The command-line interface is installed alongside the library:
+
+.. code-block:: bash
+
+    formulate --from-root 'TMath::Sqrt(x)' --to-numexpr

--- a/docs/quickstart/introduction.rst
+++ b/docs/quickstart/introduction.rst
@@ -4,37 +4,64 @@ Introduction
 What is Formulate?
 -------------------------------
 
-Formulate is a Python library that provides easy conversions between different styles of expressions. It is part of the `Scikit-HEP <https://scikit-hep.org/>`_ project, a collection of Python packages for High Energy Physics (HEP) data analysis.
+Formulate converts expressions between the syntaxes used by different analysis
+tools. It is part of the `Scikit-HEP <https://scikit-hep.org/>`_ project, a
+collection of Python packages for High Energy Physics data analysis.
 
-Currently, Formulate supports converting between:
+It reads:
 
-* `ROOT <https://root.cern.ch/doc/master/classTFormula.html>`_ style expressions (used in the TTreeFormula class)
-* `numexpr <https://numexpr.readthedocs.io/en/latest/user_guide.html>`_ style expressions
+* `ROOT <https://root.cern.ch/doc/master/classTFormula.html>`_ expressions, as
+  understood by ``TTreeFormula`` — ``TMath::Sqrt(x) && y > 2``
+* `numexpr <https://numexpr.readthedocs.io/en/latest/user_guide.html>`_
+  expressions — ``sqrt(x) & (y > 2)``
 
-This allows physicists and data analysts to write expressions in their preferred syntax and convert them to other formats as needed, facilitating interoperability between different analysis tools and frameworks.
+and writes either of those, plus plain Python using NumPy functions. The Python
+backend is output-only.
+
+The point is that a selection or a derived quantity written once, in whichever
+syntax was natural at the time, can be used with whichever tool the analysis
+needs later — without hand-translating it and hoping the precedence rules line
+up. They do not line up: ``&&`` and ``&`` bind differently against comparisons,
+and ``^`` means exponentiation in one language and XOR in the other. Formulate
+knows the difference.
 
 Simple example
 -----------------------------
 
-The most basic usage involves calling ``from_$BACKEND`` and then ``to_$BACKEND``, where ``$BACKEND`` is the format you're converting from or to.
+Parse with ``from_$BACKEND``, render with ``to_$BACKEND``:
 
-.. code-block:: python
+.. jupyter-execute::
 
     import formulate
 
-    # Create an expression object from a ROOT expression
     momentum = formulate.from_root("TMath::Sqrt(X_PX**2 + X_PY**2 + X_PZ**2)")
-    # Convert to numexpr format
-    numexpr_expression = momentum.to_numexpr()
-    print(numexpr_expression)
 
-    # ... and vice versa
+    print(momentum.to_numexpr())
+    print(momentum.to_python())
 
-Key Features
+Parsing is separate from rendering, so one parsed expression can be converted as
+many times as you like. See :doc:`example` for the same walkthrough in more
+detail.
+
+Key features
 -------------------------
 
-* Convert expressions from ROOT to numexpr format
-* Convert expressions from numexpr to ROOT format
-* Maintain the semantic meaning of expressions during conversion
-* Support for mathematical operations, logical operations, and function calls
-* Python API for programmatic conversion
+* Convert between ROOT and numexpr syntax, in either direction
+* Render any parsed expression as Python/NumPy source
+* Report the variables, named constants and numeric literals an expression uses,
+  so you know what a selection will need to read
+* Refuse, loudly, to convert what cannot be converted faithfully — the one
+  documented exception being ``%``; see :doc:`../guide/issues`
+* Parse errors that point at the problem and suggest the fix
+* A command-line interface for the same conversions
+* No dependency on ROOT or numexpr: Formulate reads and writes their syntax
+  without either being installed
+
+What Formulate is not
+-------------------------
+
+It is not an evaluator. Formulate translates the text of an expression; running
+it against data is the job of ROOT, numexpr or NumPy afterwards. It also does no
+simplification — ``2 + 2`` converts to ``(2 + 2)`` — and it does not know the
+types of your branches, which is why a handful of constructs are refused rather
+than guessed at.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -43,6 +43,7 @@ test = [
     "pytest-cov>=3",
     "hypothesis",
     "numpy",
+    "numexpr",
 ]
 
 docs = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,7 +7,8 @@ name = "formulate"
 authors = [
     { name = "Chris Burr", email = "c.b@cern.ch" },
     { name = "Aryan Roy", email = "aryanroy5678@gmail.com" },
-    { name = "Jonas Eschle", email = "jonas.eschle@gmail.com" }
+    { name = "Jonas Eschle", email = "jonas.eschle@gmail.com" },
+    { name = "Andres Rios-Tascon", email = "ariostas@gmail.com" }
 ]
 maintainers = [
     { name = "The Scikit-HEP admins", email = "scikit-hep-admins@googlegroups.com" },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -48,7 +48,7 @@ test = [
 ]
 
 docs = [
-    "sphinx>=4.0",
+    "sphinx>=5.0",
     "myst_parser>=0.13",
     "sphinx-book-theme>=0.1.0",
     "sphinx_copybutton",

--- a/src/formulate/AST.py
+++ b/src/formulate/AST.py
@@ -1,5 +1,21 @@
 # Licensed under a 3-clause BSD style license, see LICENSE.
 
+"""The backend-neutral expression tree and the serializers that render it.
+
+:func:`formulate.from_root` and :func:`formulate.from_numexpr` both return an
+:class:`AST`. Its node types (:class:`Literal`, :class:`Symbol`,
+:class:`UnaryOperator`, :class:`BinaryOperator`, :class:`Matrix` and
+:class:`Call`) are frozen dataclasses that hold *canonical* names rather than
+any one language's spelling: the ROOT ``&&``, the NumExpr ``&`` and the Python
+``&`` all parse to ``BinaryOperator(operator="and", ...)``.
+
+Rendering that tree back out is the job of :meth:`AST.to_root`,
+:meth:`AST.to_numexpr` and :meth:`AST.to_python`. Each looks its node up in the
+tables in :mod:`formulate.identifiers`; a name that is missing from a table is
+how "this construct has no faithful equivalent here" is expressed, and raises
+``ValueError`` rather than emitting something subtly different.
+"""
+
 from abc import ABCMeta, abstractmethod
 from collections.abc import Callable, Iterator, Sequence
 from dataclasses import dataclass, field
@@ -10,6 +26,7 @@ from ordered_set import OrderedSet
 from ._traversal import fold
 from .identifiers import (
     CONSTANTS,
+    FUNCTION_DISPLAY_NAMES,
     NUMEXPR_CONSTANTS,
     NUMEXPR_FUNCTIONS,
     NUMEXPR_OPERATOR_SYMBOLS,
@@ -70,6 +87,18 @@ _PYTHON = _Backend(
 
 
 class AST(metaclass=ABCMeta):
+    """Base class of every expression node.
+
+    Instances are produced by :func:`formulate.from_root` and
+    :func:`formulate.from_numexpr`, not constructed directly, and are immutable:
+    converting an expression never modifies it, so one parsed expression can be
+    rendered to as many backends as needed.
+
+    ``str(node)`` gives a language-independent view of the tree in canonical
+    names (``add(x, pow(y, 2))``), which is useful when debugging a conversion;
+    use the ``to_*`` methods to get something an engine will accept.
+    """
+
     @abstractmethod
     def _children(self) -> Sequence["AST"]: ...  # pragma: no cover
 
@@ -100,16 +129,69 @@ class AST(metaclass=ABCMeta):
         return fold(self, lambda node: (node._children(), node._serializer(backend)))
 
     def to_numexpr(self) -> str:
+        """Render the expression as NumExpr source.
+
+        Named constants have no NumExpr spelling and are substituted by their
+        numeric value, so ``pi`` comes back as ``3.141592653589793``.
+
+        :raises ValueError: if the expression uses a construct NumExpr has no
+            equivalent for, such as array indexing, ``inf``, or the
+            element-wise ``TMath::Min``/``TMath::Max``.
+
+        .. code-block:: pycon
+
+            >>> import formulate
+            >>> formulate.from_root("TMath::Sqrt(x**2 + y**2)").to_numexpr()
+            'sqrt(((x ** 2) + (y ** 2)))'
+        """
         return self._to_backend(_NUMEXPR)
 
     def to_root(self) -> str:
+        """Render the expression as a ROOT ``TTreeFormula`` string.
+
+        :raises ValueError: if the expression uses a construct ROOT has no
+            equivalent for, such as ``^`` used as XOR or NumExpr's ``where``.
+
+        .. code-block:: pycon
+
+            >>> import formulate
+            >>> formulate.from_numexpr("sqrt(x**2 + y**2)").to_root()
+            'TMath::Sqrt(((x ** 2) + (y ** 2)))'
+        """
         return self._to_backend(_ROOT)
 
     def to_python(self) -> str:
+        """Render the expression as plain Python, using NumPy for functions.
+
+        Function and constant names are emitted with an ``np.`` prefix, so the
+        result is meant to be evaluated somewhere NumPy is imported as ``np``.
+        This backend is output-only: there is no ``from_python``.
+
+        :raises ValueError: if the expression uses a construct with no NumPy
+            equivalent that can be written as a single name, such as NumExpr's
+            ``contains``.
+
+        .. code-block:: pycon
+
+            >>> import formulate
+            >>> formulate.from_root("TMath::Sqrt(x**2 + y**2)").to_python()
+            'np.sqrt(((x ** 2) + (y ** 2)))'
+        """
         return self._to_backend(_PYTHON)
 
     @property
     def variables(self) -> OrderedSet[str]:
+        """The names the expression reads, in order of first appearance.
+
+        Named constants are excluded; see :attr:`named_constants`. For a
+        ``TTree`` expression this is the set of branches that have to be read.
+
+        .. code-block:: pycon
+
+            >>> import formulate
+            >>> list(formulate.from_root("x + TMath::Pi() * y").variables)
+            ['x', 'y']
+        """
         return OrderedSet(
             node.name
             for node in self._walk()
@@ -118,6 +200,17 @@ class AST(metaclass=ABCMeta):
 
     @property
     def named_constants(self) -> OrderedSet[str]:
+        """The constants the expression names, in order of first appearance.
+
+        Names are canonical rather than as written, so both ``TMath::E()`` and
+        ``e_num`` report as ``exp1``.
+
+        .. code-block:: pycon
+
+            >>> import formulate
+            >>> list(formulate.from_root("x + TMath::Pi() * y").named_constants)
+            ['pi']
+        """
         return OrderedSet(
             node.name
             for node in self._walk()
@@ -126,13 +219,23 @@ class AST(metaclass=ABCMeta):
 
     @property
     def unnamed_constants(self) -> OrderedSet[int | float]:
+        """The numeric literals in the expression, in order of first appearance.
+
+        .. code-block:: pycon
+
+            >>> import formulate
+            >>> list(formulate.from_root("2 * x + 1.5").unnamed_constants)
+            [2, 1.5]
+        """
         return OrderedSet(
             node.value for node in self._walk() if isinstance(node, Literal)
         )
 
 
 @dataclass(frozen=True, slots=True)
-class Literal(AST):  # Literal: value that appears in the program text
+class Literal(AST):
+    """A number written out in the expression text, such as ``2`` or ``1.5``."""
+
     value: int | float
 
     def _children(self) -> Sequence[AST]:
@@ -147,7 +250,14 @@ class Literal(AST):  # Literal: value that appears in the program text
 
 
 @dataclass(frozen=True, slots=True)
-class Symbol(AST):  # Symbol: value referenced by name
+class Symbol(AST):
+    """A value referred to by name: a variable, or a named constant.
+
+    Constants are held under their canonical name (``pi``, ``exp1``) and are
+    exactly those names that appear in
+    :data:`formulate.identifiers.CONSTANTS`; every other name is a variable.
+    """
+
     name: str
 
     def _children(self) -> Sequence[AST]:
@@ -168,7 +278,14 @@ class Symbol(AST):  # Symbol: value referenced by name
 
 
 @dataclass(frozen=True, slots=True)
-class UnaryOperator(AST):  # Unary Operator: Operation with one operand
+class UnaryOperator(AST):
+    """An operation with a single operand.
+
+    ``operator`` is one of the canonical names in
+    :data:`formulate.identifiers.UNARY_OPERATORS`: ``"pos"``, ``"neg"``, or
+    ``"inv"`` for the logical NOT written ``!`` in ROOT and ``~`` in NumExpr.
+    """
+
     operator: str
     operand: AST
 
@@ -190,7 +307,14 @@ class UnaryOperator(AST):  # Unary Operator: Operation with one operand
 
 
 @dataclass(frozen=True, slots=True)
-class BinaryOperator(AST):  # Binary Operator: Operation with two operands
+class BinaryOperator(AST):
+    """An operation with two operands.
+
+    ``operator`` is one of the canonical names in
+    :data:`formulate.identifiers.BINARY_OPERATORS` — ``"add"``, ``"lt"``,
+    ``"and"`` and so on — never a backend's spelling of it.
+    """
+
     operator: str
     left: AST
     right: AST
@@ -216,7 +340,14 @@ class BinaryOperator(AST):  # Binary Operator: Operation with two operands
 
 
 @dataclass(frozen=True, slots=True)
-class Matrix(AST):  # Matrix: A matrix call
+class Matrix(AST):
+    """An indexed access, ``var[i]`` or ``var[i][j]``.
+
+    ROOT writes one bracket pair per index and Python writes a single
+    comma-separated one, so the same node renders as ``arr[1][2]`` for ROOT and
+    ``arr[1, 2]`` for Python. NumExpr has no indexing at all and rejects it.
+    """
+
     var: AST
     indices: list[AST]
 
@@ -242,7 +373,14 @@ class Matrix(AST):  # Matrix: A matrix call
 
 
 @dataclass(frozen=True, slots=True)
-class Call(AST):  # Call: evaluate a function on arguments
+class Call(AST):
+    """A function applied to zero or more arguments.
+
+    ``function`` is a canonical name from
+    :data:`formulate.identifiers.FUNCTIONS`, which is what makes
+    ``TMath::ATan2``, ``atan2`` and ``arctan2`` the same node.
+    """
+
     function: str
     arguments: list[AST]
 
@@ -266,7 +404,8 @@ class Call(AST):  # Call: evaluate a function on arguments
             return lambda base, exponent: f"({base} ** {exponent})"
         function_str = backend.functions.get(self.function)
         if function_str is None:
-            msg = f'Function "{self.function}" is not supported in {backend.name}.'
+            display = FUNCTION_DISPLAY_NAMES.get(self.function, self.function)
+            msg = f'Function "{display}" is not supported in {backend.name}.'
             raise ValueError(msg)
         name = f"{backend.function_prefix}{function_str}"
         return lambda *args: f"{name}({', '.join(args)})"

--- a/src/formulate/__init__.py
+++ b/src/formulate/__init__.py
@@ -1,5 +1,23 @@
 # Licensed under a 3-clause BSD style license, see LICENSE.
 
+"""Conversions between ROOT, NumExpr and Python expression syntax.
+
+Parse an expression with :func:`from_root` or :func:`from_numexpr`, then render
+it with :meth:`~formulate.AST.AST.to_root`,
+:meth:`~formulate.AST.AST.to_numexpr` or :meth:`~formulate.AST.AST.to_python`:
+
+.. code-block:: pycon
+
+    >>> import formulate
+    >>> formulate.from_root("TMath::Sqrt(x**2 + y**2) > 10").to_numexpr()
+    '(sqrt(((x ** 2) + (y ** 2))) > 10)'
+
+The parsed expression also reports what it refers to, through
+:attr:`~formulate.AST.AST.variables`,
+:attr:`~formulate.AST.AST.named_constants` and
+:attr:`~formulate.AST.AST.unnamed_constants`.
+"""
+
 import functools
 import importlib.resources
 
@@ -23,7 +41,28 @@ def _get_parser(parser_type: str) -> lark.Lark:
 
 
 def from_root(exp: str) -> AST.AST:
-    """Parse a ROOT expression and return an AST."""
+    """Parse a ROOT ``TTreeFormula`` expression.
+
+    The expression is parsed with C++ precedence, so ``&&`` and ``||`` bind
+    looser than a comparison, ``^`` is exponentiation rather than XOR, and
+    ``!`` is logical NOT.
+
+    :param exp: the expression to parse.
+    :returns: the parsed expression, ready to be rendered to any backend.
+    :raises ParseError: if `exp` is not valid ROOT syntax. The message points
+        at the offending location and suggests fixes for the mistakes people
+        make most often, such as writing ``&`` where ROOT wants ``&&``.
+    :raises SyntaxError: if `exp` parses but names something that cannot be a
+        symbol, or passes arguments to a constant.
+    :raises ValueError: if `exp` uses an unknown function, constant, or
+        namespace.
+
+    .. code-block:: pycon
+
+        >>> import formulate
+        >>> formulate.from_root("TMath::Abs(x) < 2.5").to_numexpr()
+        '(abs(x) < 2.5)'
+    """
     try:
         ptree = _get_parser("root").parse(exp)
     except lark.LarkError as e:
@@ -33,7 +72,29 @@ def from_root(exp: str) -> AST.AST:
 
 
 def from_numexpr(exp: str) -> AST.AST:
-    """Parse a numexpr expression and return an AST."""
+    """Parse a NumExpr expression.
+
+    The expression is parsed with Python precedence, so ``&`` and ``|`` bind
+    *tighter* than a comparison, ``^`` is XOR, and ``~`` is NOT. Chained
+    comparisons such as ``a < b < c`` are rejected, as NumExpr does not
+    support them.
+
+    :param exp: the expression to parse.
+    :returns: the parsed expression, ready to be rendered to any backend.
+    :raises ParseError: if `exp` is not valid NumExpr syntax. The message
+        points at the offending location and suggests fixes for the mistakes
+        people make most often, such as writing ``&&`` where NumExpr wants
+        ``&``.
+    :raises SyntaxError: if `exp` parses but names something that cannot be a
+        symbol, or passes arguments to a constant.
+    :raises ValueError: if `exp` uses an unknown function or constant.
+
+    .. code-block:: pycon
+
+        >>> import formulate
+        >>> formulate.from_numexpr("abs(x) < 2.5").to_root()
+        '(TMath::Abs(x) < 2.5)'
+    """
     try:
         ptree = _get_parser("numexpr").parse(exp)
     except lark.LarkError as e:

--- a/src/formulate/__init__.py
+++ b/src/formulate/__init__.py
@@ -27,7 +27,9 @@ from . import AST, exceptions, toast
 from ._version import __version__
 from .exceptions import ParseError
 
-__all__ = ["ParseError", "__version__", "from_numexpr", "from_root"]
+# Ordered by prominence rather than alphabetically: the two parsing functions
+# are the entry points, and everything else is reached through what they return.
+__all__ = ["from_numexpr", "from_root", "ParseError", "__version__"]  # noqa: RUF022
 
 
 @functools.cache

--- a/src/formulate/cli.py
+++ b/src/formulate/cli.py
@@ -1,30 +1,79 @@
 # Licensed under a 3-clause BSD style license, see LICENSE.
+
+"""The ``formulate`` command-line interface.
+
+One input option says what to parse and one output option says what to print,
+for example::
+
+    formulate --from-root '(A && B) || TMath::Sqrt(A)' --to-numexpr
+"""
+
 import argparse
 import sys
 
 from . import from_numexpr, from_root
 from ._version import __version__
 
+_EPILOG = """\
+examples:
+  formulate --from-root '(A && B) || TMath::Sqrt(A)' --to-numexpr
+  formulate --from-numexpr '(A & B) | sqrt(A)' --to-root
+  formulate --from-root 'TMath::Sqrt(x) > 5*pi' --variables
+"""
+
 
 def parse_args(args: list[str]) -> str:
+    """Run one conversion and return what the command should print.
+
+    :param args: the command-line arguments, without the program name.
+    :returns: the converted expression, or the requested names one per line.
+    :raises SystemExit: if `args` are not a valid combination, or ask for
+        ``--help`` or ``--version``.
+    """
     parser = argparse.ArgumentParser(
-        description="Convert between different types of formulae"
+        description="Convert between different styles of expressions.",
+        epilog=_EPILOG,
+        formatter_class=argparse.RawDescriptionHelpFormatter,
     )
     parser.add_argument(
         "--version", action="version", version=f"%(prog)s {__version__}"
     )
 
     from_group = parser.add_mutually_exclusive_group(required=True)
-    from_group.add_argument("--from-root")
-    from_group.add_argument("--from-numexpr")
+    from_group.add_argument(
+        "--from-root", metavar="EXPRESSION", help="parse a ROOT TTreeFormula expression"
+    )
+    from_group.add_argument(
+        "--from-numexpr", metavar="EXPRESSION", help="parse a NumExpr expression"
+    )
 
     to_group = parser.add_mutually_exclusive_group(required=True)
-    to_group.add_argument("--to-root", action="store_true")
-    to_group.add_argument("--to-numexpr", action="store_true")
-    to_group.add_argument("--to-python", action="store_true")
-    to_group.add_argument("--variables", action="store_true")
-    to_group.add_argument("--named-constants", action="store_true")
-    to_group.add_argument("--unnamed-constants", action="store_true")
+    to_group.add_argument(
+        "--to-root", action="store_true", help="print it as a ROOT expression"
+    )
+    to_group.add_argument(
+        "--to-numexpr", action="store_true", help="print it as a NumExpr expression"
+    )
+    to_group.add_argument(
+        "--to-python",
+        action="store_true",
+        help="print it as Python, using NumPy functions",
+    )
+    to_group.add_argument(
+        "--variables",
+        action="store_true",
+        help="print the variables it reads, one per line",
+    )
+    to_group.add_argument(
+        "--named-constants",
+        action="store_true",
+        help="print the named constants it uses, one per line",
+    )
+    to_group.add_argument(
+        "--unnamed-constants",
+        action="store_true",
+        help="print the numeric literals it contains, one per line",
+    )
 
     parsed_args = parser.parse_args(args)
     if parsed_args.from_root is not None:
@@ -61,5 +110,6 @@ def parse_args(args: list[str]) -> str:
 
 
 def main() -> None:
+    """Entry point of the ``formulate`` command."""
     sys.stdout.write(parse_args(sys.argv[1:]))
     sys.stdout.write("\n")

--- a/src/formulate/exceptions.py
+++ b/src/formulate/exceptions.py
@@ -1,11 +1,29 @@
 # Licensed under a 3-clause BSD style license, see LICENSE.
 
+"""Parse failures, and the hints attached to them.
+
+The parsers report a syntax error as a :class:`ParseError` whose message shows
+where parsing stopped and, where a common mistake is recognisable, how to fix
+it. The hints are heuristics over the source text, so they can suggest
+something that is not the actual problem; the underlying lark error is always
+included as well, and kept on the exception as
+:attr:`ParseError.lark_error`.
+"""
+
 import re
 
 import lark
 
 
 class ParseError(Exception):
+    """Raised when an expression cannot be parsed.
+
+    :param message: the human-readable report: where parsing stopped, any
+        suggestions, and the underlying lark message.
+    :param lark_error: the error raised by lark, kept for programmatic access
+        to details such as the line and column.
+    """
+
     def __init__(self, message: str, lark_error: lark.LarkError):
         super().__init__(message)
         self.lark_error = lark_error
@@ -30,6 +48,14 @@ def _build_parse_error(
 
 
 def debug_root(exp: str, error: lark.LarkError) -> ParseError:
+    """Turn a lark failure on a ROOT expression into a :class:`ParseError`.
+
+    Suggests the ROOT spelling of the logical operators when the expression
+    contains the NumExpr one.
+
+    :param exp: the expression that failed to parse.
+    :param error: the error lark raised for it.
+    """
     suggestions = []
     if re.search(r"(?<!&)&(?!&)", exp):
         suggestions.append("- Use '&&' instead of '&'.")
@@ -41,6 +67,15 @@ def debug_root(exp: str, error: lark.LarkError) -> ParseError:
 
 
 def debug_numexpr(exp: str, error: lark.LarkError) -> ParseError:
+    """Turn a lark failure on a NumExpr expression into a :class:`ParseError`.
+
+    Suggests the NumExpr spelling of the logical operators when the expression
+    contains the ROOT or Python one, and points out chained comparisons, which
+    NumExpr does not support.
+
+    :param exp: the expression that failed to parse.
+    :param error: the error lark raised for it.
+    """
     suggestions = []
     if "&&" in exp or " and " in exp:
         suggestions.append("- Use '&' instead of '&&' or 'and'.")

--- a/src/formulate/identifiers.py
+++ b/src/formulate/identifiers.py
@@ -1,10 +1,29 @@
 # Licensed under a 3-clause BSD style license, see LICENSE.
+
+"""The tables that say how each name is spelled in each language.
+
+``FUNCTIONS`` and ``CONSTANTS`` hold the canonical names — the ones that appear
+inside the AST — and the ``ROOT_*``, ``NUMEXPR_*`` and ``PYTHON_*`` maps give
+each backend's spelling of them. A canonical name absent from a backend's map
+is how "not supported here" is expressed: rendering it raises ``ValueError``
+rather than emitting an approximation.
+
+The ``*_ALIASES`` maps go the other way, folding the surface spellings a parser
+may see onto one canonical name, which is what makes ``TMath::ATan2``,
+``atan2`` and ``arctan2`` the same function, and ``e_num``, ``e_euler`` and
+``TMath::E()`` the same constant.
+
+Numeric values for the physical constants come from :mod:`hepunits`, so they
+agree with the rest of Scikit-HEP.
+"""
+
 import math
 
 from hepunits import constants
 from hepunits.units import coulomb, e_SI, electronvolt, joule, kelvin, m, mole, s
 
 UNARY_OPERATORS = {"pos", "neg", "inv"}
+"""Canonical names of the operators a :class:`~formulate.AST.UnaryOperator` may use."""
 
 BINARY_OPERATORS = {
     "add",
@@ -24,6 +43,7 @@ BINARY_OPERATORS = {
     "pow",
     "multi_out",
 }
+"""Canonical names of the operators a :class:`~formulate.AST.BinaryOperator` may use."""
 
 COMMON_OPERATOR_SYMBOLS = {
     "pos": "+",
@@ -41,6 +61,7 @@ COMMON_OPERATOR_SYMBOLS = {
     "neq": "!=",
     "pow": "**",
 }
+"""Operator spellings that all three languages agree on."""
 
 NUMEXPR_OPERATOR_SYMBOLS = {
     **COMMON_OPERATOR_SYMBOLS,
@@ -49,6 +70,7 @@ NUMEXPR_OPERATOR_SYMBOLS = {
     "or": "|",
     "xor": "^",
 }
+"""NumExpr's spelling of each operator."""
 
 ROOT_OPERATOR_SYMBOLS = {
     **COMMON_OPERATOR_SYMBOLS,
@@ -58,6 +80,8 @@ ROOT_OPERATOR_SYMBOLS = {
     # xor is not supported since ^ is interpreted as a power operator
     "multi_out": ":",
 }
+"""ROOT's spelling of each operator. There is no ``xor``, since ROOT reads ``^`` as
+exponentiation."""
 
 PYTHON_OPERATOR_SYMBOLS = {
     # "inv" is deliberately absent, and handled by PYTHON_UNARY_FUNCTIONS
@@ -65,6 +89,8 @@ PYTHON_OPERATOR_SYMBOLS = {
     **{op: symbol for op, symbol in NUMEXPR_OPERATOR_SYMBOLS.items() if op != "inv"},
     "multi_out": ",",
 }
+"""Python's spelling of each operator. ``inv`` is absent on purpose; see
+:data:`PYTHON_UNARY_FUNCTIONS`."""
 
 # Operators that Python spells as a function call rather than as a symbol.
 #
@@ -75,9 +101,12 @@ PYTHON_OPERATOR_SYMBOLS = {
 # unconditionally. (NumExpr needs no such treatment: its "~" has no opcode for
 # anything but booleans, so a mistranslation there fails loudly instead.)
 PYTHON_UNARY_FUNCTIONS = {"inv": "logical_not"}
+"""Unary operators Python writes as a function call rather than as a symbol. Takes
+precedence over :data:`PYTHON_OPERATOR_SYMBOLS`."""
 
 # Later on we could add Python libraries as "namespaces" here
 NAMESPACES = {"tmath"}
+"""Namespace prefixes a function name may carry, lower-cased."""
 
 FUNCTIONS = {
     # Common functions
@@ -181,6 +210,7 @@ FUNCTIONS = {
     "tmath_min",
     "tmath_max",
 }
+"""Canonical names of every function formulate knows."""
 
 FUNCTION_ALIASES = {
     "ln": "log",
@@ -193,6 +223,16 @@ FUNCTION_ALIASES = {
     "atanh": "arctanh",
     "power": "pow",
 }
+"""Other spellings of a function, mapped onto its canonical name."""
+
+# Canonical names that no language spells that way, so that an error message
+# names something the reader could have written. Every other canonical name is
+# already a spelling some language accepts, and is used as-is.
+FUNCTION_DISPLAY_NAMES = {
+    "tmath_min": "TMath::Min",
+    "tmath_max": "TMath::Max",
+}
+"""How to name a function in an error message, where its canonical name is internal."""
 
 # https://numexpr.readthedocs.io/en/latest/user_guide.html#supported-functions
 NUMEXPR_FUNCTIONS = {
@@ -233,6 +273,7 @@ NUMEXPR_FUNCTIONS = {
     # TMath::Min/TMath::Max are, and "min(a, b)" is rejected by NumExpr. The
     # equivalent is "where(a < b, a, b)", which is not a plain function name.
 }
+"""NumExpr's spelling of each function it supports."""
 
 # https://root.cern.ch/doc/master/namespaceTMath.html
 ROOT_FUNCTIONS = {
@@ -325,6 +366,7 @@ ROOT_FUNCTIONS = {
     "tmath_min": "TMath::Min",
     "tmath_max": "TMath::Max",
 }
+"""ROOT's spelling of each function it supports."""
 
 PYTHON_FUNCTIONS = {
     # NumExpr's contains() is a substring test with no NumPy equivalent that can
@@ -337,6 +379,8 @@ PYTHON_FUNCTIONS = {
     "tmath_min": "minimum",
     "tmath_max": "maximum",
 }
+"""NumPy's name for each function it supports, without the ``np.`` prefix, which is
+added when the expression is rendered."""
 
 CONSTANTS = {
     "true",
@@ -364,6 +408,8 @@ CONSTANTS = {
     "hbar",
     "hbarc",
 }
+"""Canonical names of every constant formulate knows. A :class:`~formulate.AST.Symbol`
+whose name is in here is a constant; every other symbol is a variable."""
 
 CONSTANTS_ALIASES = {
     "π": "pi",
@@ -393,6 +439,7 @@ CONSTANTS_ALIASES = {
     "degtorad": "deg2rad",
     "radtodeg": "rad2deg",
 }
+"""Other spellings of a constant, mapped onto its canonical name."""
 
 CONSTANTS_FUNCTION_ALIASES = {
     "e": "exp1",
@@ -402,6 +449,8 @@ CONSTANTS_FUNCTION_ALIASES = {
     "na": "avogadro",
     "qe": "eplus",
 }
+"""Constants recognised only in call form, such as ``c()``. Kept separate so that a bare
+``c`` stays a variable, since short branch names are common."""
 
 NUMEXPR_CONSTANTS = {
     "true": True,
@@ -427,6 +476,8 @@ NUMEXPR_CONSTANTS = {
     "hbar": constants.hbar / (electronvolt * s / e_SI),
     "hbarc": constants.hbarc / (electronvolt * m / e_SI),
 }
+"""The value substituted for each constant when rendering to NumExpr, which has no
+symbolic constants of its own."""
 
 ROOT_CONSTANTS = {
     "true": "true",
@@ -454,6 +505,7 @@ ROOT_CONSTANTS = {
     "hbar": "TMath::Hbar()",
     "hbarc": "(TMath::Hbar() * TMath::C())",
 }
+"""ROOT's spelling of each constant, usually a ``TMath`` call."""
 
 PYTHON_CONSTANTS = {
     **NUMEXPR_CONSTANTS,
@@ -461,3 +513,4 @@ PYTHON_CONSTANTS = {
     "neginf": "float('-inf')",
     "nan": "float('nan')",
 }
+"""The value substituted for each constant when rendering to Python."""

--- a/src/formulate/toast.py
+++ b/src/formulate/toast.py
@@ -1,5 +1,14 @@
 # Licensed under a 3-clause BSD style license, see LICENSE.
 
+"""Conversion of a lark parse tree into the backend-neutral AST.
+
+This is where a language's surface syntax stops mattering: namespaces
+(``TMath::``), the trailing ``$`` on ROOT's array functions, and the function
+and constant aliases are all resolved here, so what comes out is written purely
+in the canonical names of :mod:`formulate.identifiers`. A name that resolves to
+nothing raises here rather than later.
+"""
+
 import functools
 from ast import literal_eval
 from collections.abc import Callable, Sequence

--- a/tests/test_root_semantics.py
+++ b/tests/test_root_semantics.py
@@ -44,6 +44,28 @@ def test_tmath_max_to_python():
     assert out == "np.maximum(a, b)"
 
 
+@pytest.mark.parametrize(
+    "expression,expected_name",
+    [
+        ("TMath::Min(a, b)", "TMath::Min"),
+        ("TMath::Max(a, b)", "TMath::Max"),
+    ],
+)
+def test_unsupported_tmath_error_names_what_was_written(expression, expected_name):
+    # The canonical name (tmath_min) is internal and would mean nothing here.
+    with pytest.raises(ValueError) as excinfo:
+        formulate.from_root(expression).to_numexpr()
+    message = str(excinfo.value)
+    assert message == f'Function "{expected_name}" is not supported in NumExpr.'
+    assert "tmath_" not in message
+
+
+def test_unsupported_function_error_uses_its_own_name():
+    with pytest.raises(ValueError) as excinfo:
+        formulate.from_numexpr("where(a, b, c)").to_root()
+    assert str(excinfo.value) == 'Function "where" is not supported in ROOT.'
+
+
 # --- Bare $ functions without parentheses ---
 
 


### PR DESCRIPTION
:robot: _AI text below_ :robot:

The docs had drifted from the code. Some pages were wrong, some were placeholders, and the public API rendered as a list of bare signatures because nothing in it had a docstring.

## Things that were wrong

- `installation.rst` claimed conda-forge was not available yet, in a sentence that was also missing its closing parenthesis. It has been available since v1.0.0.
- `example.rst` showed a ROOT output with unbalanced parentheses that the code never produces.
- `questions.rst` illustrated a failure with an expression that parses fine (`problematic_expression` is a valid symbol), and pointed at a Stack Overflow tag for an unrelated product.
- `speed.rst` and `citations.rst` were the word "TODO".
- The `toast` API page documented `keyword.iskeyword` with the docstring `x.__contains__(y) <==> y in x`, and the `identifiers` page rendered completely empty — both artifacts of `:undoc-members:`.
- `AGENTS.md` said "five" AST node types and listed six.

## Things that were missing

- `to_python()` / `--to-python` appeared nowhere outside one aside in `issues.rst`, and neither did `.variables` / `.named_constants` / `.unnamed_constants`, indexing, or ROOT's `:` operator.
- `guide/expressions.rst` listed 17 of ~80 functions and no constants at all. It now covers every operator, function and constant with its spelling in each language, generated from the identifier tables so the "not supported" entries match what actually raises. Physical constants now carry their units, which were documented nowhere.
- Docstrings for the whole public surface, plus module docstrings and attribute docstrings on the identifier tables — the latter are what autodoc needs to stop falling back to `dict.__doc__`.
- `speed.rst` written from measurements; `citations.rst` written against the Scikit-HEP citation page.
- The CLI had no `help=` text for any flag, so `formulate --help` listed them bare.
- `CHANGELOG` gained an Unreleased section for the eight commits that have touched `src` since v1.0.1.

## One behaviour change

Converting `TMath::Min`/`TMath::Max` to numexpr reported `Function "tmath_min" is not supported`, naming an internal identifier nobody writes. `FUNCTION_DISPLAY_NAMES` maps those two canonical names back to what a user would have typed. Every other canonical name is already a spelling some language accepts (`where`, `pow`, `sqrt`), so those messages are unchanged — a second test pins that down.

## Notes

Examples in narrative pages are now `jupyter-execute` rather than hand-written `# Output:` comments, so a stale example fails the build instead of misinforming the reader. `AGENTS.md` gained a short section on which page owns what, for the same reason.

`conf.py` picks up intersphinx and the autodoc settings the above needs, and the copyright year is bumped.

Verified: docs build clean under `-W --keep-going`, `prek run --all-files` passes, 1956 tests pass with coverage still at 100%.

🤖 Generated with [Claude Code](https://claude.com/claude-code)