### PR TITLE
fix: a few more findings from a codebase review

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,4 +1,0 @@
-[report]
-exclude_lines =
-    pragma: no cover
-    raise NotImplementedError

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -32,10 +32,67 @@ jobs:
 
       - uses: hynek/build-and-inspect-python-package@d44ca7d91762de7a7d5436ddae667c6da6d1c3df # v2.18.0
 
+  # The full test matrix, as a gate on publishing. It is skipped outside a
+  # release because the same workflow already runs on every push and pull
+  # request; running it here too would only duplicate it.
+  tests:
+    name: Tests
+    if: github.event_name == 'release' && github.event.action == 'published'
+    uses: ./.github/workflows/ci.yml
+    # Passed explicitly rather than inherited: this is the only secret the
+    # called workflow uses.
+    secrets:
+      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+
+  # Tests run from a checkout exercise the source tree, so they cannot catch a
+  # packaging mistake -- a grammar left out of the wheel, say, since the .lark
+  # files are package data. Install what was actually built and test that.
+  smoke:
+    name: Test the built ${{ matrix.package }}
+    needs: [dist]
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - package: wheel
+            pattern: "*.whl"
+          - package: sdist
+            pattern: "*.tar.gz"
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+
+      - uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
+        with:
+          python-version: "3.13"
+
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: Packages
+          path: dist
+
+      - name: Install the built ${{ matrix.package }}
+        env:
+          PACKAGE_PATTERN: ${{ matrix.pattern }}
+        run: |
+          package=$(find dist -maxdepth 1 -name "${PACKAGE_PATTERN}")
+          test -f "${package}" || { echo "no unique ${PACKAGE_PATTERN} in dist/"; exit 1; }
+          python -m pip install "${package}[test]"
+
+      - name: Run the test suite against the installed package
+        # The package lives in src/ and the pytest config sets no pythonpath,
+        # so `import formulate` from the checkout root can only resolve to what
+        # was just installed. The path is printed to keep that checkable.
+        run: |
+          python -c "import formulate, pathlib; print(pathlib.Path(formulate.__file__).parent)"
+          python -m pytest tests -q
+
   deploy:
     name: Deploy to PyPI
     if: github.event_name == 'release' && github.event.action == 'published'
-    needs: [dist]
+    needs: [dist, tests, smoke]
     runs-on: ubuntu-latest
     environment:
       name: pypi

--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -39,10 +39,6 @@ jobs:
     name: Tests
     if: github.event_name == 'release' && github.event.action == 'published'
     uses: ./.github/workflows/ci.yml
-    # Passed explicitly rather than inherited: this is the only secret the
-    # called workflow uses.
-    secrets:
-      CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
   # Tests run from a checkout exercise the source tree, so they cannot catch a
   # packaging mistake -- a grammar left out of the wheel, say, since the .lark

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,9 +67,16 @@ jobs:
         run: |
           pytest -vv --cov=formulate --cov-branch --cov-report=xml --junitxml=junit.xml -o junit_family=legacy
 
-      # Skipped when CD calls this workflow: `github.event_name` is then the
-      # caller's `release`. That run is a gate on publishing, it reports a
-      # commit codecov already has, and it is passed no token to upload with.
+      # Skipped when CD calls this workflow. That run is a gate on publishing:
+      # it reports a commit codecov already has, and is passed no token to
+      # upload with.
+      #
+      # The condition tests the *caller's* event, which is what `github` holds
+      # in a called workflow -- `github.event_name` is never `workflow_call`,
+      # however much it looks as though it should be. Rewriting this as
+      # `== 'workflow_call'` is a standing temptation and silently breaks it,
+      # since that matches nothing and the steps then run everywhere. See
+      # actions/runner#3146.
       - name: Upload coverage to Codecov
         if: runner.os == 'Linux' && matrix.python-version == '3.10' && github.event_name != 'release'
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,11 +2,10 @@ name: unittests
 
 on:
   # Callable so that CD can require this whole matrix before publishing;
-  # GitHub has no way to depend on a job in another workflow.
+  # GitHub has no way to depend on a job in another workflow. That call wants
+  # the tests as a gate and nothing else, so it uploads no coverage and needs
+  # no secrets.
   workflow_call:
-    secrets:
-      CODECOV_TOKEN:
-        required: false
   workflow_dispatch:
   push:
     tags:
@@ -68,14 +67,17 @@ jobs:
         run: |
           pytest -vv --cov=formulate --cov-branch --cov-report=xml --junitxml=junit.xml -o junit_family=legacy
 
+      # Skipped when CD calls this workflow: `github.event_name` is then the
+      # caller's `release`. That run is a gate on publishing, it reports a
+      # commit codecov already has, and it is passed no token to upload with.
       - name: Upload coverage to Codecov
-        if: runner.os == 'Linux' && matrix.python-version == '3.10'
+        if: runner.os == 'Linux' && matrix.python-version == '3.10' && github.event_name != 'release'
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
 
       - name: Upload test results to Codecov
-        if: ${{ !cancelled() && runner.os == 'Linux' && matrix.python-version == '3.10' }}
+        if: ${{ !cancelled() && runner.os == 'Linux' && matrix.python-version == '3.10' && github.event_name != 'release' }}
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:
           token: ${{ secrets.CODECOV_TOKEN }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,12 @@
 name: unittests
 
 on:
+  # Callable so that CD can require this whole matrix before publishing;
+  # GitHub has no way to depend on a job in another workflow.
+  workflow_call:
+    secrets:
+      CODECOV_TOKEN:
+        required: false
   workflow_dispatch:
   push:
     tags:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,15 +55,18 @@ Pipeline, in order:
    that assembles the AST node from them.
 3. **`AST.py`** — six frozen dataclass node types (`Literal`, `Symbol`, `UnaryOperator`,
    `BinaryOperator`, `Matrix`, `Call`) plus a `_Backend` descriptor. A node type implements
-   exactly four things: `_children()`, `_key()` — the node's own data, everything that is
-   not a child — `_format(*parts)` for `str()`, and `_serializer(backend)`, which returns
-   the builder that joins its already-serialized children. Every traversal lives on the base
-   class and is iterative: `__str__`, `_to_backend` and `__hash__` are all `_traversal.fold`
-   calls, `__eq__` walks two trees on an explicit stack of pairs, and `_walk` backs
-   `variables` / `named_constants` / `unnamed_constants`. Nothing here recurses, so depth is
-   bounded by memory, not by the stack. The nodes are declared `eq=False` precisely so the
-   dataclass does not generate the recursive `__eq__`/`__hash__` that would undo this; a new
-   node type must repeat that. The three public `to_*` methods just pass the corresponding
+   exactly three things: `_children()`, `_format(*parts)` for `str()`, and
+   `_serializer(backend)`, which returns the builder that joins its already-serialized
+   children. Every traversal lives on the base class and is iterative: `__str__` and
+   `_to_backend` are both `_traversal.fold` calls, and `_walk` backs `variables` /
+   `named_constants` / `unnamed_constants`. Nothing here recurses, so depth is bounded by
+   memory, not by the stack. **Nodes are deliberately not comparable or hashable**: `__eq__`
+   raises and `__hash__` is `None`, because structural equality would call `a + b` and
+   `b + a` different expressions while semantic equality is computer algebra, well outside
+   what a syntax translator can promise. Compare `str(node)` or a `to_*` rendering instead —
+   serialization is canonical, which is what the tests do. The nodes are declared `eq=False`
+   so the dataclass does not generate an `__eq__`/`__hash__` that would override that; a new
+   node type must repeat it. The three public `to_*` methods just pass the corresponding
    `_Backend` instance (`_ROOT`, `_NUMEXPR`, `_PYTHON`). There is no per-backend visitor
    class — a new backend is a new `_Backend` literal plus new tables. Every node validates in
    `_serializer`, which runs before its children are visited, so an expression with more than
@@ -142,11 +145,11 @@ contains a lone `&`. New syntax that people commonly get wrong belongs here.
 - `filterwarnings = ["error"]` and `xfail_strict` are on — a new warning fails the suite.
 - mypy runs `--strict` over `src` only; the package ships `py.typed`.
 - Supported Python is 3.10+, and the CI matrix includes Windows and free-threaded 3.14.
-- **No recursive tree walks.** `_traversal.fold`, `AST._walk` and `AST.__eq__` are the only
-  three, and all use an explicit stack, so peak frame depth is a small constant whatever the
-  expression size. Watch for walks arriving implicitly rather than being written: the
-  dataclass-generated `__eq__`/`__hash__` recurse through child fields, which is why the
-  nodes set `eq=False` and the base class implements both itself.
+- **No recursive tree walks.** `_traversal.fold` and `AST._walk` are the only two, and both
+  use an explicit stack, so peak frame depth is a small constant whatever the expression
+  size. Watch for walks arriving implicitly rather than being written: a dataclass-generated
+  `__eq__`/`__hash__` would recurse through child fields, which is one more reason the nodes
+  set `eq=False`.
   `tests/test_performance.py` runs at CPython's default recursion limit on purpose and nests
   1,000 levels deep, so a recursive walk added back anywhere fails there. The sizes in that file are
   bounded by its 3s timing budget on the slowest job (Windows/3.10 under coverage), not by the

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -55,12 +55,15 @@ Pipeline, in order:
    that assembles the AST node from them.
 3. **`AST.py`** — six frozen dataclass node types (`Literal`, `Symbol`, `UnaryOperator`,
    `BinaryOperator`, `Matrix`, `Call`) plus a `_Backend` descriptor. A node type implements
-   exactly three things: `_children()`, `_format(*parts)` for `str()`, and
-   `_serializer(backend)`, which returns the builder that joins its already-serialized
-   children. Every traversal lives on the base class and is iterative: `__str__` and
-   `_to_backend` are both `_traversal.fold` calls, and `_walk` backs `variables` /
-   `named_constants` / `unnamed_constants`. Nothing here recurses, so depth is bounded by
-   memory, not by the stack. The three public `to_*` methods just pass the corresponding
+   exactly four things: `_children()`, `_key()` — the node's own data, everything that is
+   not a child — `_format(*parts)` for `str()`, and `_serializer(backend)`, which returns
+   the builder that joins its already-serialized children. Every traversal lives on the base
+   class and is iterative: `__str__`, `_to_backend` and `__hash__` are all `_traversal.fold`
+   calls, `__eq__` walks two trees on an explicit stack of pairs, and `_walk` backs
+   `variables` / `named_constants` / `unnamed_constants`. Nothing here recurses, so depth is
+   bounded by memory, not by the stack. The nodes are declared `eq=False` precisely so the
+   dataclass does not generate the recursive `__eq__`/`__hash__` that would undo this; a new
+   node type must repeat that. The three public `to_*` methods just pass the corresponding
    `_Backend` instance (`_ROOT`, `_NUMEXPR`, `_PYTHON`). There is no per-backend visitor
    class — a new backend is a new `_Backend` literal plus new tables. Every node validates in
    `_serializer`, which runs before its children are visited, so an expression with more than
@@ -134,8 +137,11 @@ contains a lone `&`. New syntax that people commonly get wrong belongs here.
 - `filterwarnings = ["error"]` and `xfail_strict` are on — a new warning fails the suite.
 - mypy runs `--strict` over `src` only; the package ships `py.typed`.
 - Supported Python is 3.10+, and the CI matrix includes Windows and free-threaded 3.14.
-- **No recursive tree walks.** `_traversal.fold` and `AST._walk` are the only two, and both
-  use an explicit stack, so peak frame depth is a small constant whatever the expression size.
+- **No recursive tree walks.** `_traversal.fold`, `AST._walk` and `AST.__eq__` are the only
+  three, and all use an explicit stack, so peak frame depth is a small constant whatever the
+  expression size. Watch for walks arriving implicitly rather than being written: the
+  dataclass-generated `__eq__`/`__hash__` recurse through child fields, which is why the
+  nodes set `eq=False` and the base class implements both itself.
   `tests/test_performance.py` runs at CPython's default recursion limit on purpose and nests
   1,000 levels deep, so a recursive walk added back anywhere fails there. The sizes in that file are
   bounded by its 3s timing budget on the slowest job (Windows/3.10 under coverage), not by the

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,7 +18,7 @@ prek install                # hook runner; reads .pre-commit-config.yaml
 
 pytest                      # all tests
 pytest tests/test_root.py -k tmath_min       # single file / single test
-pytest --cov=formulate --cov-branch          # with coverage
+pytest --cov=formulate                       # with coverage; fails under 100%
 
 nox                         # default: lint + pylint + tests
 nox -s tests                # tests in an isolated env
@@ -132,8 +132,13 @@ contains a lone `&`. New syntax that people commonly get wrong belongs here.
 
 ## Constraints to respect
 
-- **Coverage is enforced at 100%** for both project and patch (`codecov.yml`, threshold 0).
-  Genuinely unreachable code is marked `# pragma: no cover`; prefer deleting dead branches.
+- **Coverage is enforced at 100%** for both project and patch (`codecov.yml`, threshold 0),
+  and locally too: `[tool.coverage]` in `pyproject.toml` turns on branch coverage and sets
+  `fail_under = 100`, so any `--cov` run — `nox -s coverage`, or CI — fails on a gap rather
+  than only being caught by codecov after a push. That also means `--cov` on a filtered
+  subset of tests will fail; leave it off when running one test. The suite reaches 100%
+  without ROOT installed, so every job in the matrix can meet it. Genuinely unreachable code
+  is marked `# pragma: no cover`; prefer deleting dead branches.
 - `filterwarnings = ["error"]` and `xfail_strict` are on — a new warning fails the suite.
 - mypy runs `--strict` over `src` only; the package ships `py.typed`.
 - Supported Python is 3.10+, and the CI matrix includes Windows and free-threaded 3.14.

--- a/docs/guide/expressions.rst
+++ b/docs/guide/expressions.rst
@@ -404,7 +404,7 @@ NumExpr-specific functions
    * - ``complex``
      - —
      - ``complex``
-     - ``np.complex128``
+     - —
    * - ``contains``
      - —
      - ``contains``
@@ -412,6 +412,13 @@ NumExpr-specific functions
 
 ``contains`` is a substring test, and NumPy has no equivalent that can be
 written as a single function name, so it converts to neither of the other two.
+
+``complex`` is the same story. ``np.complex128`` looks like the counterpart,
+but it is a scalar *type* constructor rather than an element-wise function: it
+accepts 0-d input only and raises ``TypeError`` on arrays, which is what these
+expressions are almost always evaluated against. The element-wise form is
+``a + 1j*b``, an expression rather than a name, so ``to_python()`` refuses it
+instead of emitting something that works only for single values.
 
 ROOT-specific functions
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/guide/expressions.rst
+++ b/docs/guide/expressions.rst
@@ -634,7 +634,12 @@ you want when deciding which branches to read from a file:
    print(list(expr.named_constants))
    print(list(expr.unnamed_constants))
 
-Names come out in the order they first appear, and each is reported once.
+Names come out in the order they first appear, and each is reported once. They
+are reported as ROOT spells them, which for a dotted branch name is *not* how
+``to_numexpr()`` writes it — numexpr cannot take a dot, so those names are
+hex-encoded on the way out and it is the encoded name you must supply when you
+evaluate. See :ref:`issues-dotted-names`.
+
 ``str()`` on the expression shows the parsed structure in canonical names, which
 is the quickest way to check how something was grouped:
 

--- a/docs/guide/expressions.rst
+++ b/docs/guide/expressions.rst
@@ -159,6 +159,13 @@ comma-separated list that Python reads as a tuple:
 NumExpr evaluates a single expression and has no equivalent, so converting one
 of these raises.
 
+``:`` separates whole expressions rather than combining two values, so it is
+only accepted between them -- ``a:b`` and ``a+1 : b*2`` are fine, but
+``(a:b)+c`` and ``sqrt(a:b)`` are rejected, as they are by ROOT. This is also
+what lets it be the one operator that is never parenthesized: were it allowed
+to nest, ``(a:b)+c`` would have to serialize as ``a : b + c`` and would read
+back as ``a:(b+c)``.
+
 Indexing
 ----------------
 

--- a/docs/guide/issues.rst
+++ b/docs/guide/issues.rst
@@ -88,6 +88,13 @@ Two that are easy to trip over:
   convert to numexpr's ``min`` and ``max``.
 * numexpr's ``contains()`` is a string operation with no ROOT or NumPy
   counterpart.
+* A numeric literal too large for a double, such as ``1e999``, overflows to
+  infinity. None of the three languages can write infinity as a *literal*, so
+  it is read as the ``inf`` constant above and follows exactly the same rules:
+  ``TMath::Infinity()`` for ROOT, ``float('inf')`` for Python, and the
+  ``ValueError`` shown above for numexpr. It is reported under
+  :attr:`~formulate.AST.AST.named_constants` rather than
+  :attr:`~formulate.AST.AST.unnamed_constants` for the same reason.
 
 ``^`` is exponentiation in ROOT and XOR in numexpr
 ---------------------------------------------------------------------------

--- a/docs/guide/issues.rst
+++ b/docs/guide/issues.rst
@@ -88,6 +88,10 @@ Two that are easy to trip over:
   convert to numexpr's ``min`` and ``max``.
 * numexpr's ``contains()`` is a string operation with no ROOT or NumPy
   counterpart.
+* numexpr's ``complex(a, b)`` builds a complex array element-wise. NumPy's
+  ``np.complex128`` is a scalar type constructor, not that function, so it is
+  not used as a translation: ``to_python()`` raises rather than emit a call
+  that raises ``TypeError`` the moment its arguments are arrays.
 * A numeric literal too large for a double, such as ``1e999``, overflows to
   infinity. None of the three languages can write infinity as a *literal*, so
   it is read as the ``inf`` constant above and follows exactly the same rules:

--- a/docs/guide/issues.rst
+++ b/docs/guide/issues.rst
@@ -152,3 +152,45 @@ original name:
    '3.141592653589793'
 
 The value is preserved; only the spelling is lost.
+
+.. _issues-dotted-names:
+
+Dotted branch names are hex-encoded for numexpr
+---------------------------------------------------------------------------
+
+ROOT's ``branch.leaf`` is a single branch name that happens to contain a dot,
+not an attribute access. numexpr rejects any expression containing one
+("forbidden control characters") and has no quoting syntax to get around it, so
+formulate encodes the name the same way uproot encodes C++ class names: each
+run of characters that cannot appear in an identifier becomes those bytes in
+hexadecimal, wrapped in underscores.
+
+.. jupyter-execute::
+
+   import formulate
+
+   formulate.from_root("branch.leaf > 10").to_numexpr()
+
+**This is the name you have to supply when you evaluate.** ``.`` is ``0x2e``,
+so the array above must be passed to numexpr as ``branch_2e_leaf``, not as
+``branch.leaf``. :attr:`~formulate.AST.AST.variables` reports the original
+name, since the tree keeps ROOT's spelling:
+
+.. jupyter-execute::
+
+   list(formulate.from_root("branch.leaf > 10").variables)
+
+Underscores are encoded too when they sit inside a name that is being encoded,
+which is what keeps ``a.b_c`` (``a_2e_b_5f_c``) distinct from a branch really
+called ``a_2e_b_c``. Names that numexpr can already spell are passed through
+untouched, so an ordinary ``pt_corrected`` is left alone.
+
+The encoding is not undone on the way back: ``from_numexpr`` cannot tell an
+encoded ``branch.leaf`` from a branch genuinely named ``branch_2e_leaf``, and
+silently renaming the latter would be worse than not restoring the former. A
+ROOT → numexpr → ROOT round trip therefore keeps the encoded spelling, in the
+same way it keeps the numeric value of a named constant.
+
+ROOT and Python are unaffected. Note that ``to_python()`` emits the dot as
+written, where it is a genuine attribute lookup — which is what you want only
+if you evaluate against an object rather than a dict keyed by branch name.

--- a/noxfile.py
+++ b/noxfile.py
@@ -96,9 +96,12 @@ def build(session: nox.Session) -> None:
     Build an SDist and wheel.
     """
 
-    build_p = DIR.joinpath("build")
-    if build_p.exists():
-        shutil.rmtree(build_p)
+    # `python -m build` writes into dist/ without clearing it first, so stale
+    # wheels and sdists from earlier versions would otherwise pile up there and
+    # be picked up by anything that globs dist/*.
+    dist_p = DIR.joinpath("dist")
+    if dist_p.exists():
+        shutil.rmtree(dist_p)
 
     session.install("build")
     session.run("python", "-m", "build")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -177,7 +177,6 @@ basic.module-rgx = "(([a-z_][a-z0-9_]*)|(AST))$"
 # remainder are pylint's own defaults, kept.
 classes.exclude-protected = [
     "_children",
-    "_key",
     "_format",
     "_serializer",
     "_asdict",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -168,6 +168,24 @@ py-version = "3.10"
 ignore-paths = ["src/formulate/_version.py"]
 reports.output-format = "colorized"
 similarities.ignore-imports = "yes"
+# pylint's default, plus `AST`: `formulate.AST` is public API, so the module
+# cannot be renamed to snake_case without breaking imports.
+basic.module-rgx = "(([a-z_][a-z0-9_]*)|(AST))$"
+# The node protocol -- see AST.py. These are private to the package rather than
+# to the instance: the base class and `fold` deliberately call them on nodes
+# other than self, which is what makes every traversal live in one place. The
+# remainder are pylint's own defaults, kept.
+classes.exclude-protected = [
+    "_children",
+    "_key",
+    "_format",
+    "_serializer",
+    "_asdict",
+    "_fields",
+    "_replace",
+    "_source",
+    "_make",
+]
 messages_control.disable = [
     "design",
     "fixme",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -96,6 +96,24 @@ testpaths = [
 ]
 
 
+# Coverage is measured with branches and required to be complete, matching what
+# codecov.yml enforces on a pull request. Keeping it here rather than in the CI
+# invocation means `pytest --cov=formulate` and `nox -s coverage` hold a change
+# to the same standard before it is pushed. The full suite reaches 100% without
+# ROOT installed, so every job in the matrix can meet this, not just the one
+# that uploads.
+[tool.coverage.run]
+branch = true
+source = ["formulate"]
+
+[tool.coverage.report]
+fail_under = 100
+# Only the default. The `raise NotImplementedError` exclusion this replaces was
+# redundant: both raises sit under an `else:` already marked `# pragma: no
+# cover`, which is how this package spells genuinely unreachable code.
+exclude_lines = ["pragma: no cover"]
+
+
 [tool.mypy]
 files = "src"
 python_version = "3.10"

--- a/src/formulate/AST.py
+++ b/src/formulate/AST.py
@@ -126,6 +126,11 @@ class AST(metaclass=ABCMeta):
     use the ``to_*`` methods to get something an engine will accept.
     """
 
+    # The node types are all slotted dataclasses, but a slotted class inheriting
+    # from an unslotted one still gets a __dict__, which would undo that for
+    # every node in the tree.
+    __slots__ = ()
+
     @abstractmethod
     def _children(self) -> Sequence["AST"]: ...  # pragma: no cover
 

--- a/src/formulate/AST.py
+++ b/src/formulate/AST.py
@@ -117,13 +117,16 @@ class AST(metaclass=ABCMeta):
     """Base class of every expression node.
 
     Instances are produced by :func:`formulate.from_root` and
-    :func:`formulate.from_numexpr`, not constructed directly, and are immutable
-    and hashable: converting an expression never modifies it, so one parsed
+    :func:`formulate.from_numexpr`, not constructed directly, and are
+    immutable: converting an expression never modifies it, so one parsed
     expression can be rendered to as many backends as needed.
 
     ``str(node)`` gives a language-independent view of the tree in canonical
     names (``add(x, pow(y, 2))``), which is useful when debugging a conversion;
     use the ``to_*`` methods to get something an engine will accept.
+
+    Nodes are deliberately neither comparable nor hashable. ``==`` and
+    ``hash()`` both raise ``TypeError``; see :meth:`__eq__`.
     """
 
     # The node types are all slotted dataclasses, but a slotted class inheriting
@@ -135,9 +138,6 @@ class AST(metaclass=ABCMeta):
     def _children(self) -> Sequence["AST"]: ...  # pragma: no cover
 
     @abstractmethod
-    def _key(self) -> tuple[Any, ...]: ...  # pragma: no cover
-
-    @abstractmethod
     def _format(self, *parts: str) -> str: ...  # pragma: no cover
 
     @abstractmethod
@@ -146,44 +146,36 @@ class AST(metaclass=ABCMeta):
     ) -> Callable[..., str]: ...  # pragma: no cover
 
     def __eq__(self, other: object) -> bool:
-        """Compare two trees structurally, without recursing.
+        """Always raise: expression equality is not something this package answers.
 
-        The dataclass-generated ``__eq__`` compares field tuples, and a field
-        holding a child node makes that a recursive descent -- which blows the
-        interpreter stack on trees the rest of this class handles fine.
+        Structural equality is easy to provide and wrong often enough to
+        mislead. It would report ``a + b`` and ``b + a`` as different
+        expressions, along with ``x * 1`` and ``x``, ``(a + b) + c`` and
+        ``a + (b + c)``, and any spelling of a constant that is not the one
+        that happened to be parsed. Deciding those properly is computer
+        algebra, which is a long way outside what a syntax translator can
+        promise.
+
+        Comparing the serializations is well defined and is what the tests in
+        this package do: ``str(node)`` for the canonical form, or one of the
+        ``to_*`` renderings for a particular language. Those are deterministic
+        and fully parenthesized, so equal strings mean identically shaped
+        trees -- the honest version of what a structural ``==`` would have
+        said.
         """
-        if self is other:
-            return True
-        if not isinstance(other, AST):
-            return NotImplemented
-        stack: list[tuple[AST, AST]] = [(self, other)]
-        while stack:
-            left, right = stack.pop()
-            if left is right:
-                continue
-            if type(left) is not type(right) or left._key() != right._key():
-                return False
-            left_children, right_children = left._children(), right._children()
-            if len(left_children) != len(right_children):
-                return False
-            # Lengths were just checked, so strict= can never trip here; it is
-            # there to keep that a stated invariant rather than a silent one.
-            stack.extend(zip(left_children, right_children, strict=True))
-        return True
-
-    def __hash__(self) -> int:
-        """Hash the tree bottom-up, for the same reason ``__eq__`` is iterative.
-
-        Equal trees have equal types, keys and child structure, so they hash
-        alike.
-        """
-        return fold(
-            self,
-            lambda node: (
-                node._children(),
-                lambda *children: hash((type(node), node._key(), children)),
-            ),
+        msg = (
+            "AST nodes cannot be compared. Equality would have to choose "
+            "between a structural answer, which calls 'a + b' and 'b + a' "
+            "different, and a semantic one, which is out of scope for this "
+            "package. Compare str(node), or node.to_root() / .to_numexpr() / "
+            ".to_python(), all of which are canonical."
         )
+        raise TypeError(msg)
+
+    # Unhashable for the same reason: a hash has to agree with an equality that
+    # does not exist. `None` rather than a raising method so that the object is
+    # honestly not Hashable, as `isinstance(node, Hashable)` reports.
+    __hash__ = None  # type: ignore[assignment]
 
     def _walk(self) -> Iterator["AST"]:
         """Yield every node in the tree, parents first and left to right.
@@ -316,9 +308,6 @@ class Literal(AST):
     def _children(self) -> Sequence[AST]:
         return ()
 
-    def _key(self) -> tuple[Any, ...]:
-        return (self.value,)
-
     def _format(self, *_parts: str) -> str:
         return str(self.value)
 
@@ -340,9 +329,6 @@ class Symbol(AST):
 
     def _children(self) -> Sequence[AST]:
         return ()
-
-    def _key(self) -> tuple[Any, ...]:
-        return (self.name,)
 
     def _format(self, *_parts: str) -> str:
         return self.name
@@ -380,9 +366,6 @@ class UnaryOperator(AST):
     def _children(self) -> Sequence[AST]:
         return (self.operand,)
 
-    def _key(self) -> tuple[Any, ...]:
-        return (self.operator,)
-
     def _format(self, *parts: str) -> str:
         return f"{self.operator}({parts[0]})"
 
@@ -412,9 +395,6 @@ class BinaryOperator(AST):
 
     def _children(self) -> Sequence[AST]:
         return (self.left, self.right)
-
-    def _key(self) -> tuple[Any, ...]:
-        return (self.operator,)
 
     def _format(self, *parts: str) -> str:
         return f"{self.operator}({parts[0]}, {parts[1]})"
@@ -446,9 +426,6 @@ class Matrix(AST):
 
     def _children(self) -> Sequence[AST]:
         return (self.var, *self.indices)
-
-    def _key(self) -> tuple[Any, ...]:
-        return ()
 
     def _format(self, *parts: str) -> str:
         var_str, *indices = parts
@@ -482,9 +459,6 @@ class Call(AST):
 
     def _children(self) -> Sequence[AST]:
         return self.arguments
-
-    def _key(self) -> tuple[Any, ...]:
-        return (self.function,)
 
     def _format(self, *parts: str) -> str:
         return f"{self.function}({', '.join(parts)})"

--- a/src/formulate/AST.py
+++ b/src/formulate/AST.py
@@ -16,6 +16,7 @@ how "this construct has no faithful equivalent here" is expressed, and raises
 ``ValueError`` rather than emitting something subtly different.
 """
 
+import re
 from abc import ABCMeta, abstractmethod
 from collections.abc import Callable, Iterator, Sequence
 from dataclasses import dataclass, field
@@ -55,6 +56,9 @@ class _Backend:
     index_format: str | None = (
         "python"  # None = forbidden, "root" = [x][y], "python" = [x,y]
     )
+    # Whether a name this backend cannot spell is hex-encoded rather than
+    # emitted as written. See `_encode_name`.
+    encode_invalid_names: bool = False
 
 
 _NUMEXPR = _Backend(
@@ -64,6 +68,7 @@ _NUMEXPR = _Backend(
     constants=NUMEXPR_CONSTANTS,
     pow_as_operator=True,
     index_format=None,
+    encode_invalid_names=True,
 )
 
 _ROOT = _Backend(
@@ -84,6 +89,28 @@ _PYTHON = _Backend(
     unparenthesized_ops=frozenset({","}),
     unary_functions=PYTHON_UNARY_FUNCTIONS,
 )
+
+
+# ROOT branch names are not always identifiers -- `branch.leaf` is one name with
+# a dot in it, not an attribute access -- but NumExpr rejects any expression
+# containing one ("forbidden control characters") and has no quoting syntax to
+# get around it. Uproot has the same problem with C++ classnames and solves it
+# by hex-encoding, so formulate spells names the same way uproot does: a run of
+# characters that cannot appear in an identifier becomes those bytes in hex,
+# wrapped in underscores, making `branch.leaf` into `branch_2e_leaf`.
+#
+# A dot is the only such character that can reach here: `toast` requires every
+# dot-separated part of a symbol to be a Python identifier, so anything else is
+# a parse error long before this. The pattern is still uproot's, so that names
+# encode identically in both packages, which also means underscores are part of
+# a run: `a.b_c` encodes to `a_2e_b_5f_c` rather than to an `a_2e_b_c` that a
+# branch really called `a_2e_b_c` would collide with.
+_ENCODE_RUN = re.compile(r"[^A-Za-z0-9]+")
+
+
+def _encode_name(name: str) -> str:
+    """Hex-encode the parts of `name` that cannot appear in an identifier."""
+    return _ENCODE_RUN.sub(lambda run: f"_{run.group().encode().hex()}_", name)
 
 
 class AST(metaclass=ABCMeta):
@@ -328,6 +355,8 @@ class Symbol(AST):
                 # unary minus, so the sign would escape the exponent and
                 # ``eminus ** 2`` would come out negative.
                 text = f"({text})"
+        elif backend.encode_invalid_names and "." in self.name:
+            text = _encode_name(self.name)
         return lambda: text
 
 

--- a/src/formulate/AST.py
+++ b/src/formulate/AST.py
@@ -103,12 +103,55 @@ class AST(metaclass=ABCMeta):
     def _children(self) -> Sequence["AST"]: ...  # pragma: no cover
 
     @abstractmethod
+    def _key(self) -> tuple[Any, ...]: ...  # pragma: no cover
+
+    @abstractmethod
     def _format(self, *parts: str) -> str: ...  # pragma: no cover
 
     @abstractmethod
     def _serializer(
         self, backend: _Backend
     ) -> Callable[..., str]: ...  # pragma: no cover
+
+    def __eq__(self, other: object) -> bool:
+        """Compare two trees structurally, without recursing.
+
+        The dataclass-generated ``__eq__`` compares field tuples, and a field
+        holding a child node makes that a recursive descent -- which blows the
+        interpreter stack on trees the rest of this class handles fine.
+        """
+        if self is other:
+            return True
+        if not isinstance(other, AST):
+            return NotImplemented
+        stack: list[tuple[AST, AST]] = [(self, other)]
+        while stack:
+            left, right = stack.pop()
+            if left is right:
+                continue
+            if type(left) is not type(right) or left._key() != right._key():
+                return False
+            left_children, right_children = left._children(), right._children()
+            if len(left_children) != len(right_children):
+                return False
+            # Lengths were just checked, so strict= can never trip here; it is
+            # there to keep that a stated invariant rather than a silent one.
+            stack.extend(zip(left_children, right_children, strict=True))
+        return True
+
+    def __hash__(self) -> int:
+        """Hash the tree bottom-up, for the same reason ``__eq__`` is iterative.
+
+        Equal trees have equal types, keys and child structure, so they hash
+        alike.
+        """
+        return fold(
+            self,
+            lambda node: (
+                node._children(),
+                lambda *children: hash((type(node), node._key(), children)),
+            ),
+        )
 
     def _walk(self) -> Iterator["AST"]:
         """Yield every node in the tree, parents first and left to right.
@@ -232,7 +275,7 @@ class AST(metaclass=ABCMeta):
         )
 
 
-@dataclass(frozen=True, slots=True)
+@dataclass(frozen=True, slots=True, eq=False)
 class Literal(AST):
     """A number written out in the expression text, such as ``2`` or ``1.5``."""
 
@@ -240,6 +283,9 @@ class Literal(AST):
 
     def _children(self) -> Sequence[AST]:
         return ()
+
+    def _key(self) -> tuple[Any, ...]:
+        return (self.value,)
 
     def _format(self, *_parts: str) -> str:
         return str(self.value)
@@ -249,7 +295,7 @@ class Literal(AST):
         return lambda: text
 
 
-@dataclass(frozen=True, slots=True)
+@dataclass(frozen=True, slots=True, eq=False)
 class Symbol(AST):
     """A value referred to by name: a variable, or a named constant.
 
@@ -262,6 +308,9 @@ class Symbol(AST):
 
     def _children(self) -> Sequence[AST]:
         return ()
+
+    def _key(self) -> tuple[Any, ...]:
+        return (self.name,)
 
     def _format(self, *_parts: str) -> str:
         return self.name
@@ -282,7 +331,7 @@ class Symbol(AST):
         return lambda: text
 
 
-@dataclass(frozen=True, slots=True)
+@dataclass(frozen=True, slots=True, eq=False)
 class UnaryOperator(AST):
     """An operation with a single operand.
 
@@ -296,6 +345,9 @@ class UnaryOperator(AST):
 
     def _children(self) -> Sequence[AST]:
         return (self.operand,)
+
+    def _key(self) -> tuple[Any, ...]:
+        return (self.operator,)
 
     def _format(self, *parts: str) -> str:
         return f"{self.operator}({parts[0]})"
@@ -311,7 +363,7 @@ class UnaryOperator(AST):
         return lambda operand: f"({symbol}{operand})"
 
 
-@dataclass(frozen=True, slots=True)
+@dataclass(frozen=True, slots=True, eq=False)
 class BinaryOperator(AST):
     """An operation with two operands.
 
@@ -326,6 +378,9 @@ class BinaryOperator(AST):
 
     def _children(self) -> Sequence[AST]:
         return (self.left, self.right)
+
+    def _key(self) -> tuple[Any, ...]:
+        return (self.operator,)
 
     def _format(self, *parts: str) -> str:
         return f"{self.operator}({parts[0]}, {parts[1]})"
@@ -343,7 +398,7 @@ class BinaryOperator(AST):
         return lambda left, right: f"({left}{separator}{right})"
 
 
-@dataclass(frozen=True, slots=True)
+@dataclass(frozen=True, slots=True, eq=False)
 class Matrix(AST):
     """An indexed access, ``var[i]`` or ``var[i][j]``.
 
@@ -357,6 +412,9 @@ class Matrix(AST):
 
     def _children(self) -> Sequence[AST]:
         return (self.var, *self.indices)
+
+    def _key(self) -> tuple[Any, ...]:
+        return ()
 
     def _format(self, *parts: str) -> str:
         var_str, *indices = parts
@@ -376,7 +434,7 @@ class Matrix(AST):
         return build
 
 
-@dataclass(frozen=True, slots=True)
+@dataclass(frozen=True, slots=True, eq=False)
 class Call(AST):
     """A function applied to zero or more arguments.
 
@@ -390,6 +448,9 @@ class Call(AST):
 
     def _children(self) -> Sequence[AST]:
         return self.arguments
+
+    def _key(self) -> tuple[Any, ...]:
+        return (self.function,)
 
     def _format(self, *parts: str) -> str:
         return f"{self.function}({', '.join(parts)})"

--- a/src/formulate/_traversal.py
+++ b/src/formulate/_traversal.py
@@ -36,8 +36,10 @@ def fold(
     while stack:
         item = stack.pop()
         # An exact type check, not isinstance: it is what tells a pending
-        # builder apart from a node, and nodes are never plain tuples.
-        if type(item) is tuple:
+        # builder apart from a node, and nodes are never plain tuples. A node
+        # that subclassed tuple would satisfy isinstance and be mistaken for a
+        # builder, so the stricter check is the point here.
+        if type(item) is tuple:  # pylint: disable=unidiomatic-typecheck
             build, nargs = item
             if nargs:
                 parts = results[-nargs:]

--- a/src/formulate/exceptions.py
+++ b/src/formulate/exceptions.py
@@ -63,6 +63,13 @@ def debug_root(exp: str, error: lark.LarkError) -> ParseError:
         suggestions.append("- Use '||' instead of '|'.")
     if "~" in exp:
         suggestions.append("- Use '!' instead of '~'.")
+    # A lone ':', so that the '::' of TMath::Sqrt does not trigger this.
+    if re.search(r"(?<!:):(?!:)", exp):
+        suggestions.append(
+            "- ':' separates the expressions of a TTree::Draw and is only "
+            "allowed between whole expressions, not inside parentheses or "
+            "function arguments."
+        )
     return _build_parse_error(exp, error, suggestions)
 
 

--- a/src/formulate/identifiers.py
+++ b/src/formulate/identifiers.py
@@ -369,12 +369,22 @@ ROOT_FUNCTIONS = {
 """ROOT's spelling of each function it supports."""
 
 PYTHON_FUNCTIONS = {
-    # NumExpr's contains() is a substring test with no NumPy equivalent that can
-    # be written as a single function name (np.strings.find(a, b) != -1 is an
-    # expression, not a name), so Python rejects it just as ROOT does.
-    **{name: func for name, func in NUMEXPR_FUNCTIONS.items() if name != "contains"},
+    # Two NumExpr functions have no NumPy equivalent that can be written as a
+    # single function name, so Python rejects them just as ROOT does:
+    #
+    # contains()  a substring test; np.strings.find(a, b) != -1 is an
+    #             expression, not a name.
+    # complex()   element-wise construction from a real and an imaginary part.
+    #             np.complex128 looks like the counterpart but is a scalar type
+    #             constructor: it takes 0-d input only and raises TypeError on
+    #             arrays, which is the shape this library exists to convert. The
+    #             element-wise form is a + 1j*b, again an expression.
+    **{
+        name: func
+        for name, func in NUMEXPR_FUNCTIONS.items()
+        if name not in ("contains", "complex")
+    },
     "pow": "power",
-    "complex": "complex128",
     # np.minimum/maximum are the element-wise equivalents of TMath::Min/Max
     "tmath_min": "minimum",
     "tmath_max": "maximum",

--- a/src/formulate/resources/root_grammar.lark
+++ b/src/formulate/resources/root_grammar.lark
@@ -3,10 +3,17 @@
 # The bitwise operators &, |, ~ are not supported, and the bitwise operator ^ is interpreted as exponentiation.
 # Shift operators are also not supported.
 
-start: expression
+start: outputs
+
+# ':' separates the several expressions of a TTree::Draw, so it is only
+# meaningful at the very top of one. It is not an operator: making it one would
+# let it appear inside parentheses and function arguments, where ROOT does not
+# accept it and where serialization -- which never parenthesizes ':' -- would
+# reassociate it, so `(a:b)+c` came back as `a:(b+c)`.
+outputs: expression
+       | outputs ":" expression -> multi_out
 
 expression: disjunction
-          | expression ":" disjunction -> multi_out
 
 disjunction: conjunction
            | disjunction "||" conjunction -> or

--- a/src/formulate/toast.py
+++ b/src/formulate/toast.py
@@ -96,17 +96,19 @@ def _expand(ptnode: lark.Tree) -> tuple[Sequence[Any], Callable[..., AST.AST]]:
     errors it raises — happens here, before they are visited.
     """
     match ptnode:
-        case lark.Tree(operator, (left, right)) if operator in BINARY_OPERATORS:
+        case lark.Tree(data=operator, children=(left, right)) if (
+            operator in BINARY_OPERATORS
+        ):
             return (left, right), functools.partial(AST.BinaryOperator, operator)
 
-        case lark.Tree(operator, operand) if operator in UNARY_OPERATORS:
+        case lark.Tree(data=operator, children=operand) if operator in UNARY_OPERATORS:
             return (operand[0],), functools.partial(AST.UnaryOperator, operator)
 
-        case lark.Tree("matr", (array, *indices)):
+        case lark.Tree(data="matr", children=(array, *indices)):
             children = [array, *(elem.children[0] for elem in indices)]
             return children, lambda mat, *ind: AST.Matrix(mat, ind)
 
-        case lark.Tree("func", (func_name, trailer)):
+        case lark.Tree(data="func", children=(func_name, trailer)):
             func_name = _get_function_name(func_name)
 
             # In case the function is actually a constant
@@ -123,7 +125,7 @@ def _expand(ptnode: lark.Tree) -> tuple[Sequence[Any], Callable[..., AST.AST]]:
             arguments = () if arg_list is None else tuple(arg_list.children)
             return arguments, lambda *args: AST.Call(func_name, args)
 
-        case lark.Tree("symbol", children):
+        case lark.Tree(data="symbol", children=children):
             var_name = _get_var_name(children[0])
             if var_name in ("True", "False"):
                 var_name = var_name.lower()  # This makes it not a keyword
@@ -140,7 +142,7 @@ def _expand(ptnode: lark.Tree) -> tuple[Sequence[Any], Callable[..., AST.AST]]:
                 raise SyntaxError(msg)
             return (), _constant(AST.Symbol(var_name))
 
-        case lark.Tree("literal", children):
+        case lark.Tree(data="literal", children=children):
             value = literal_eval(children[0])
             # A literal too big for a double overflows to infinity, and there
             # is no way to write infinity as a *literal* in any of the three
@@ -152,7 +154,7 @@ def _expand(ptnode: lark.Tree) -> tuple[Sequence[Any], Callable[..., AST.AST]]:
                 return (), _constant(AST.Symbol("inf"))
             return (), _constant(AST.Literal(value))
 
-        case lark.Tree(_, (child,)):
+        case lark.Tree(children=(child,)):
             return (child,), lambda child_exp: child_exp
 
         case _:  # pragma: no cover

--- a/src/formulate/toast.py
+++ b/src/formulate/toast.py
@@ -10,6 +10,7 @@ nothing raises here rather than later.
 """
 
 import functools
+import math
 from ast import literal_eval
 from collections.abc import Callable, Sequence
 from keyword import iskeyword
@@ -140,7 +141,16 @@ def _expand(ptnode: lark.Tree) -> tuple[Sequence[Any], Callable[..., AST.AST]]:
             return (), _constant(AST.Symbol(var_name))
 
         case lark.Tree("literal", children):
-            return (), _constant(AST.Literal(literal_eval(children[0])))
+            value = literal_eval(children[0])
+            # A literal too big for a double overflows to infinity, and there
+            # is no way to write infinity as a *literal* in any of the three
+            # languages -- rendering it would emit a bare `inf`, which is not
+            # valid input to any of them. It is exactly the canonical `inf`
+            # constant though, which already knows that ROOT spells it
+            # `TMath::Infinity()` and that NumExpr cannot spell it at all.
+            if isinstance(value, float) and math.isinf(value):
+                return (), _constant(AST.Symbol("inf"))
+            return (), _constant(AST.Literal(value))
 
         case lark.Tree(_, (child,)):
             return (child,), lambda child_exp: child_exp

--- a/tests/test_ast_properties.py
+++ b/tests/test_ast_properties.py
@@ -74,6 +74,32 @@ def test_nodes_compare_by_value(left, right, equal):
     assert (left == right) is equal
 
 
+def test_identical_objects_short_circuit():
+    """Both the whole-tree fast path and the per-child one inside the walk."""
+    node = Call("sqrt", (Symbol("a"),))
+    assert node == node
+    shared = Symbol("a")
+    assert BinaryOperator("add", shared, Literal(1)) == BinaryOperator(
+        "add", shared, Literal(1)
+    )
+
+
+def test_comparison_with_a_non_node_is_not_implemented():
+    """Returning NotImplemented rather than False is what lets Python fall back
+    to the other operand's __eq__, and keeps `!=` consistent."""
+    assert Symbol("a").__eq__("a") is NotImplemented
+    assert Symbol("a") != "a"
+
+
+def test_nodes_of_the_same_type_but_different_arity_differ():
+    """Arity is not part of `_key`, so it is the child count that separates
+    these -- a shape the grammar cannot produce for Call, but Matrix can."""
+    assert Call("sqrt", (Symbol("a"),)) != Call("sqrt", (Symbol("a"), Symbol("b")))
+    assert Matrix(Symbol("a"), (Literal(0),)) != Matrix(
+        Symbol("a"), (Literal(0), Literal(1))
+    )
+
+
 def test_nodes_are_immutable():
     with pytest.raises(AttributeError):
         Symbol("a").name = "b"

--- a/tests/test_ast_properties.py
+++ b/tests/test_ast_properties.py
@@ -9,6 +9,8 @@ BinaryOperator with an operator no backend supports) and pin the behaviour of
 
 from __future__ import annotations
 
+from collections.abc import Hashable
+
 import pytest
 from ordered_set import OrderedSet
 
@@ -42,11 +44,11 @@ def test_str_representation(node, expected):
     assert str(node) == expected
 
 
-# --- Nodes are frozen value objects ---
+# --- Nodes are frozen, and neither comparable nor hashable ---
 
 
 @pytest.mark.parametrize(
-    "left,right,equal",
+    "left,right,same",
     [
         (Literal(1.0), Literal(1.0), True),
         (Literal(1.0), Literal(2.0), False),
@@ -68,36 +70,47 @@ def test_str_representation(node, expected):
         (Call("sqrt", (Symbol("a"),)), Call("sqrt", (Symbol("a"),)), True),
         (Call("sqrt", (Symbol("a"),)), Call("abs", (Symbol("a"),)), False),
         (Matrix(Symbol("a"), (Literal(0),)), Matrix(Symbol("a"), (Literal(0),)), True),
+        (
+            Matrix(Symbol("a"), (Literal(0),)),
+            Matrix(Symbol("a"), (Literal(0), Literal(1))),
+            False,
+        ),
     ],
 )
-def test_nodes_compare_by_value(left, right, equal):
-    assert (left == right) is equal
+def test_the_canonical_string_distinguishes_nodes(left, right, same):
+    """With `==` gone, the serialization is what tells two trees apart. It is
+    deterministic and fully parenthesized, so identically shaped trees give the
+    identical string and differently shaped ones do not -- which is the part of
+    equality this package can actually promise."""
+    assert (str(left) == str(right)) is same
 
 
-def test_identical_objects_short_circuit():
-    """Both the whole-tree fast path and the per-child one inside the walk."""
-    node = Call("sqrt", (Symbol("a"),))
-    assert node == node
-    shared = Symbol("a")
-    assert BinaryOperator("add", shared, Literal(1)) == BinaryOperator(
-        "add", shared, Literal(1)
-    )
+def test_nodes_cannot_be_compared():
+    """Equality would have to choose between a structural answer, which calls
+    `a + b` and `b + a` different expressions, and a semantic one, which is
+    computer algebra rather than translation. It raises instead of quietly
+    giving the misleading one."""
+    left = formulate.from_root("a+b")
+    right = formulate.from_root("a+b")
+    for operation in (
+        lambda: left == right,
+        lambda: left != right,
+        lambda: left == "a+b",  # including against a non-node
+        lambda: left in [right],  # and wherever a container reaches for ==
+    ):
+        with pytest.raises(TypeError, match="cannot be compared"):
+            operation()
 
 
-def test_comparison_with_a_non_node_is_not_implemented():
-    """Returning NotImplemented rather than False is what lets Python fall back
-    to the other operand's __eq__, and keeps `!=` consistent."""
-    assert Symbol("a").__eq__("a") is NotImplemented
-    assert Symbol("a") != "a"
-
-
-def test_nodes_of_the_same_type_but_different_arity_differ():
-    """Arity is not part of `_key`, so it is the child count that separates
-    these -- a shape the grammar cannot produce for Call, but Matrix can."""
-    assert Call("sqrt", (Symbol("a"),)) != Call("sqrt", (Symbol("a"), Symbol("b")))
-    assert Matrix(Symbol("a"), (Literal(0),)) != Matrix(
-        Symbol("a"), (Literal(0), Literal(1))
-    )
+def test_nodes_cannot_be_hashed():
+    """`__hash__` is None rather than a method that raises, so a node is
+    honestly not Hashable rather than merely failing when hashed."""
+    parsed = formulate.from_root("a+b")
+    with pytest.raises(TypeError, match="unhashable type"):
+        hash(parsed)
+    with pytest.raises(TypeError, match="unhashable type"):
+        {parsed}  # noqa: B018
+    assert not isinstance(parsed, Hashable)
 
 
 def test_nodes_are_immutable():
@@ -105,12 +118,9 @@ def test_nodes_are_immutable():
         Symbol("a").name = "b"
 
 
-def test_every_node_of_a_parsed_tree_is_hashable():
-    # Children are held in tuples, not lists, so a node can be used as a dict
-    # key or set member -- Call and Matrix are the ones that hold several.
+def test_a_parsed_tree_can_hold_every_node_type():
     parsed = formulate.from_root("TMath::Max(a[0][1], -b) + !c > pi")
-    node_types = {type(node).__name__ for node in parsed._walk()}
-    assert node_types == {
+    assert {type(node).__name__ for node in parsed._walk()} == {
         "Literal",
         "Symbol",
         "UnaryOperator",
@@ -118,15 +128,11 @@ def test_every_node_of_a_parsed_tree_is_hashable():
         "Matrix",
         "Call",
     }
-    assert len({hash(node) for node in parsed._walk()}) > 1
-    assert hash(parsed) == hash(
-        formulate.from_root("TMath::Max(a[0][1], -b) + !c > pi")
-    )
 
 
-def test_equal_expressions_from_different_sources_compare_equal():
-    assert formulate.from_root("a+b") == formulate.from_numexpr("a+b")
-    assert formulate.from_root("a+b") != formulate.from_numexpr("b+a")
+def test_the_two_parsers_build_the_same_tree_for_shared_syntax():
+    assert str(formulate.from_root("a+b")) == str(formulate.from_numexpr("a+b"))
+    assert str(formulate.from_root("a+b")) != str(formulate.from_numexpr("b+a"))
 
 
 # --- Symbol classification ---

--- a/tests/test_comprehensive_features.py
+++ b/tests/test_comprehensive_features.py
@@ -144,6 +144,31 @@ def test_python_only_literal_forms_are_rejected(expr):
         formulate.from_numexpr(expr)
 
 
+@pytest.mark.parametrize("parse", [formulate.from_root, formulate.from_numexpr])
+def test_a_literal_too_large_for_a_double_becomes_the_inf_constant(parse):
+    """None of the three languages can write infinity as a literal, so an
+    overflowing one is handed to the constant machinery instead of being
+    emitted as a bare ``inf`` that no engine would accept back."""
+    parsed = parse("1e999")
+    assert parsed == Symbol("inf")
+    assert parsed.named_constants == OrderedSet(["inf"])
+    assert parsed.unnamed_constants == OrderedSet()
+
+    assert parsed.to_root() == "TMath::Infinity()"
+    assert parsed.to_python() == "float('inf')"
+    with pytest.raises(ValueError, match="not supported in NumExpr"):
+        parsed.to_numexpr()
+
+
+@pytest.mark.parametrize("parse", [formulate.from_root, formulate.from_numexpr])
+def test_a_literal_a_double_can_still_hold_stays_a_literal(parse):
+    """The boundary the test above depends on: 1e300 is finite, so it is
+    unaffected and still round-trips through NumExpr."""
+    parsed = parse("1e300")
+    assert parsed == Literal(1e300)
+    assert parsed.to_numexpr() == "1e+300"
+
+
 # --- String handling ---
 
 

--- a/tests/test_comprehensive_features.py
+++ b/tests/test_comprehensive_features.py
@@ -150,7 +150,8 @@ def test_a_literal_too_large_for_a_double_becomes_the_inf_constant(parse):
     overflowing one is handed to the constant machinery instead of being
     emitted as a bare ``inf`` that no engine would accept back."""
     parsed = parse("1e999")
-    assert parsed == Symbol("inf")
+    assert isinstance(parsed, Symbol)
+    assert parsed.name == "inf"
     assert parsed.named_constants == OrderedSet(["inf"])
     assert parsed.unnamed_constants == OrderedSet()
 
@@ -165,7 +166,8 @@ def test_a_literal_a_double_can_still_hold_stays_a_literal(parse):
     """The boundary the test above depends on: 1e300 is finite, so it is
     unaffected and still round-trips through NumExpr."""
     parsed = parse("1e300")
-    assert parsed == Literal(1e300)
+    assert isinstance(parsed, Literal)
+    assert parsed.value == 1e300
     assert parsed.to_numexpr() == "1e+300"
 
 
@@ -210,7 +212,7 @@ def test_contains_is_a_numexpr_only_function():
     ],
 )
 def test_root_and_numexpr_parsers_build_the_same_tree(expr):
-    assert formulate.from_root(expr) == formulate.from_numexpr(expr)
+    assert str(formulate.from_root(expr)) == str(formulate.from_numexpr(expr))
 
 
 # --- Translation tables ---

--- a/tests/test_comprehensive_features.py
+++ b/tests/test_comprehensive_features.py
@@ -240,18 +240,23 @@ def test_function_translations_go_both_ways(numexpr_expr, root_expr):
         ("c_light", 299792458.0, "TMath::C()"),
         ("eminus", -1.602176634e-19, "(-TMath::Qe())"),
         ("eplus", 1.602176634e-19, "TMath::Qe()"),
+        # h/2pi and hbar*c, in the same SI (joule-based) units as the rest of
+        # the table -- not the natural units hepunits states them in.
         ("h_planck", 6.62607015e-34, "TMath::H()"),
-        ("hbar", 6.62607015e-34, "TMath::Hbar()"),
-        ("hbarc", 1.97326968e-16, "(TMath::Hbar() * TMath::C())"),
+        ("hbar", 1.054571817e-34, "TMath::Hbar()"),
+        ("hbarc", 3.16152677e-26, "(TMath::Hbar() * TMath::C())"),
     ],
 )
 def test_constant_translations(canonical, value, root_expr):
     assert formulate.from_numexpr(canonical).to_root() == root_expr
-    # Both spellings must inline to the same number in NumExpr
+    # Both spellings must inline to the same number in NumExpr.  The comparison
+    # is relative with no absolute floor: np.isclose's default atol of 1e-8
+    # exceeds several of these constants outright, so it would accept any value
+    # at all for them -- including zero.
     from_canonical = eval(formulate.from_numexpr(canonical).to_numexpr())
     from_root = eval(formulate.from_root(root_expr).to_numexpr())
-    assert np.isclose(from_canonical, value)
-    assert np.isclose(from_root, value)
+    assert np.isclose(from_canonical, value, rtol=1e-8, atol=0.0)
+    assert np.isclose(from_root, value, rtol=1e-8, atol=0.0)
 
 
 # --- variables / named_constants / unnamed_constants ---

--- a/tests/test_constants.py
+++ b/tests/test_constants.py
@@ -60,11 +60,25 @@ def numexpr_eval_with(expression: str, **values: float) -> float:
     )
 
 
+# Compared *relatively*, with no absolute floor.  np.isclose's default atol of
+# 1e-8 is larger than several of the constants checked here -- hbar is 1e-34 --
+# so under it any two of them compare equal, and equal to zero, which makes
+# this file's central claim vacuous for exactly the values hardest to eyeball.
+#
+# 1e-8 is a bound on how far the two engines are actually observed to disagree,
+# not a round number: every comparison below is bit-exact except hbar and hbarc
+# at 6e-10, where ROOT hardcodes CODATA's rounded 1.054571817e-34 and hepunits
+# divides the exact h by 2*pi.  Tightening past that is what fails.
+RELATIVE_TOLERANCE = 1e-8
+
+
 def assert_same_value(left: float, right: float, context: str) -> None:
     if np.isnan(left):
         assert np.isnan(right), f"{context}: {left} != {right}"
     else:
-        assert np.isclose(left, right), f"{context}: {left} != {right}"
+        assert np.isclose(left, right, rtol=RELATIVE_TOLERANCE, atol=0.0), (
+            f"{context}: {left} != {right}"
+        )
 
 
 # --- Constants ---

--- a/tests/test_cycle.py
+++ b/tests/test_cycle.py
@@ -116,6 +116,7 @@ ROOT_ONLY_EXPRESSIONS = [
     "Length$(a)",
     "Length$()",
     "a:b",
+    "branch.leaf",
     "TMath::Pi()",
     "TMath::Infinity()",
     "TMath::QuietNaN()",

--- a/tests/test_failures.py
+++ b/tests/test_failures.py
@@ -123,6 +123,7 @@ def test_parse_error_says_so_when_it_has_no_suggestions():
         ("a|b", "Use '||' instead of '|'."),
         ("a||b|c", "Use '||' instead of '|'."),
         ("~a", "Use '!' instead of '~'."),
+        ("(a:b)+c", "':' separates the expressions of a TTree::Draw"),
     ],
 )
 def test_root_suggestions(expr, suggestion):
@@ -146,6 +147,14 @@ def test_numexpr_suggestions(expr, suggestion):
     with pytest.raises(ParseError) as excinfo:
         formulate.from_numexpr(expr)
     assert suggestion in str(excinfo.value)
+
+
+def test_namespace_colons_do_not_trigger_the_multi_out_suggestion():
+    """'TMath::' is two colons, not the ':' separator, so a failure that merely
+    mentions a namespace must not be blamed on multi-output syntax."""
+    with pytest.raises(ParseError) as excinfo:
+        formulate.from_root("TMath::Sqrt(x")
+    assert "TTree::Draw" not in str(excinfo.value)
 
 
 def test_not_equal_does_not_trigger_the_bang_suggestion():

--- a/tests/test_failures.py
+++ b/tests/test_failures.py
@@ -192,7 +192,10 @@ def test_invalid_characters(s):
     """Text made only of punctuation should never parse."""
     # Skip strings that contain only whitespace or valid operators
     assume(not s.isspace())
-    assume(not all(c in "+-*/()<>=!&|^~_\r " for c in s))  # TODO: why does _ not fail?
+    # '_' is a valid symbol on its own, and every kind of whitespace is ignored
+    # by the grammar rather than rejected, so a string made only of those parses
+    # and is not a counterexample.
+    assume(not all(c in "+-*/()<>=!&|^~_" or c.isspace() for c in s))
 
     with pytest.raises(ParseError):
         formulate.from_root(s)

--- a/tests/test_identifiers.py
+++ b/tests/test_identifiers.py
@@ -161,6 +161,27 @@ def test_contains_is_not_offered_by_the_python_backend():
         formulate.from_numexpr("contains(s, t)").to_python()
 
 
+def test_complex_is_not_offered_by_the_python_backend():
+    """np.complex128 is a scalar type constructor, not the element-wise
+    counterpart of NumExpr's complex(): it raises TypeError on array input, so
+    emitting it would produce code that only works for the 0-d case."""
+    assert "complex" not in PYTHON_FUNCTIONS
+    with pytest.raises(ValueError, match="not supported in Python"):
+        formulate.from_numexpr("complex(a, b)").to_python()
+
+    # The premise, so this test fails rather than goes stale if NumPy ever
+    # makes np.complex128 element-wise.
+    with pytest.raises(TypeError):
+        np.complex128(np.array([1.0, 2.0]), np.array([3.0, 4.0]))
+
+
+def test_complex_still_converts_between_numexpr_and_itself():
+    """Only the Python backend loses it; NumExpr keeps its own spelling."""
+    assert formulate.from_numexpr("complex(a, b)").to_numexpr() == "complex(a, b)"
+    with pytest.raises(ValueError, match="not supported in ROOT"):
+        formulate.from_numexpr("complex(a, b)").to_root()
+
+
 @pytest.mark.parametrize(
     "rendering",
     [pytest.param(value, id=name) for name, value in sorted(PYTHON_CONSTANTS.items())],

--- a/tests/test_performance.py
+++ b/tests/test_performance.py
@@ -97,23 +97,6 @@ def test_deeply_nested_calls_survive_every_walk():
     assert parsed.variables == {"a"}
 
 
-def test_deeply_nested_calls_compare_and_hash():
-    """`==` and `hash` are walks too, and were the last recursive ones: the
-    dataclass-generated versions descend one frame per level and raise
-    RecursionError on a tree every other walk here handles."""
-    expression = "sqrt(" * DEEP_NESTING + "a" + ")" * DEEP_NESTING
-    parsed = formulate.from_root(expression)
-    same = formulate.from_root(expression)
-    different = formulate.from_root("sqrt(" * DEEP_NESTING + "b" + ")" * DEEP_NESTING)
-
-    assert parsed == same
-    assert parsed != different
-    assert hash(parsed) == hash(same)
-    # A difference at the very bottom still has to be found, so this is the
-    # case that walks the full depth rather than stopping at the root.
-    assert len({parsed, same, different}) == 2
-
-
 @pytest.mark.parametrize(
     "name,length,parse,serialize",
     [

--- a/tests/test_performance.py
+++ b/tests/test_performance.py
@@ -97,6 +97,23 @@ def test_deeply_nested_calls_survive_every_walk():
     assert parsed.variables == {"a"}
 
 
+def test_deeply_nested_calls_compare_and_hash():
+    """`==` and `hash` are walks too, and were the last recursive ones: the
+    dataclass-generated versions descend one frame per level and raise
+    RecursionError on a tree every other walk here handles."""
+    expression = "sqrt(" * DEEP_NESTING + "a" + ")" * DEEP_NESTING
+    parsed = formulate.from_root(expression)
+    same = formulate.from_root(expression)
+    different = formulate.from_root("sqrt(" * DEEP_NESTING + "b" + ")" * DEEP_NESTING)
+
+    assert parsed == same
+    assert parsed != different
+    assert hash(parsed) == hash(same)
+    # A difference at the very bottom still has to be found, so this is the
+    # case that walks the full depth rather than stopping at the root.
+    assert len({parsed, same, different}) == 2
+
+
 @pytest.mark.parametrize(
     "name,length,parse,serialize",
     [

--- a/tests/test_root_semantics.py
+++ b/tests/test_root_semantics.py
@@ -177,3 +177,30 @@ def test_multi_out_is_not_parenthesized():
 
 def test_multi_out_becomes_a_comma_in_python():
     assert formulate.from_root("a:b").to_python() == "a, b"
+
+
+@pytest.mark.parametrize(
+    "expr",
+    [
+        "(a:b)+c",
+        "(a:b)",
+        "-(a:b)",
+        "sqrt(a:b)",
+        "TMath::Max(a:b, c)",
+        "arr[a:b]",
+    ],
+)
+def test_multi_out_is_rejected_below_the_top_level(expr):
+    """Because ':' is never parenthesized, a nested one could not be written
+    back out unambiguously: `(a:b)+c` used to serialize as `a : b + c` and
+    re-parse as `a:(b+c)`. ROOT does not accept these either -- ':' is how
+    TTree::Draw separates whole expressions, not an operator.
+    """
+    with pytest.raises(formulate.ParseError):
+        formulate.from_root(expr)
+
+
+def test_multi_out_survives_a_round_trip_at_the_top_level():
+    for expr in ("a:b", "a:b:c", "a+1:b*2"):
+        serialized = formulate.from_root(expr).to_root()
+        assert formulate.from_root(serialized).to_root() == serialized

--- a/tests/test_root_semantics.py
+++ b/tests/test_root_semantics.py
@@ -66,6 +66,51 @@ def test_unsupported_function_error_uses_its_own_name():
     assert str(excinfo.value) == 'Function "where" is not supported in ROOT.'
 
 
+# --- branch.leaf is one name, not an attribute access ---
+
+
+def test_dotted_names_survive_the_backends_that_have_them():
+    expr = formulate.from_root("branch.leaf + 1")
+    assert expr.variables == {"branch.leaf"}
+    assert expr.to_root() == "(branch.leaf + 1)"
+    assert expr.to_python() == "(branch.leaf + 1)"
+
+
+@pytest.mark.parametrize(
+    "name,encoded",
+    [
+        ("branch.leaf", "branch_2e_leaf"),  # '.' is 0x2e
+        ("x.y.z", "x_2e_y_2e_z"),
+        # '_' is escaped as 0x5f inside a name that is being encoded, so this
+        # cannot collide with the encoding of `a.b.c`.
+        ("a.b_c", "a_2e_b_5f_c"),
+        # Names NumExpr can already spell are left exactly as written, which is
+        # why an underscore on its own is not encoded.
+        ("pt_corrected", "pt_corrected"),
+        ("pt", "pt"),
+    ],
+)
+def test_numexpr_names_are_hex_encoded_only_where_they_have_to_be(name, encoded):
+    """NumExpr rejects any expression containing a dot and has no quoting
+    syntax, so a name it cannot spell is encoded the way uproot encodes C++
+    classnames rather than emitted as-is or refused."""
+    assert formulate.from_root(name).to_numexpr() == encoded
+
+
+def test_only_the_offending_symbol_is_encoded():
+    assert (
+        formulate.from_root("branch.leaf + other").to_numexpr()
+        == "(branch_2e_leaf + other)"
+    )
+
+
+def test_encoding_is_not_undone_on_the_way_back():
+    """from_numexpr does not decode: a branch really named `branch_2e_leaf` is
+    indistinguishable from an encoded `branch.leaf`, and silently renaming the
+    former would be worse than not restoring the latter."""
+    assert formulate.from_numexpr("branch_2e_leaf").to_root() == "branch_2e_leaf"
+
+
 # --- Bare $ functions without parentheses ---
 
 


### PR DESCRIPTION
These were a few more things that were found after a review with GPT 5.6 Sol.

The most important change is the dotted names one. I had some discussions with Jonas about this a while ago and we temporarily decided to keep dots in numexpr outputs even though they were not valid. But I've been thinking about it more, and I think the right approach is to actually output valid numexpr expressions. For this, I borrowed the idea from Uproot of converting invalid symbols (in this case only `.`) into their hex representation surrounded by parenthesis. This makes a lot of sense to me, and is what we will use in Uproot once we integrate Formulate as the expression parser.

🤖 AI text below 🤖

Acts on an external review of the codebase. Each finding was reproduced before
being fixed, and a few were rejected — see the end.

Every commit is independent and the branch is green throughout: 1,993 tests
pass, coverage is 100% for both statements and branches, `prek run --all-files`
is clean, and `nox` (lint + pylint + tests) and `nox -s docs` both succeed.

## Correctness

**Constants were not actually being checked.** `assert_same_value` and
`test_constant_translations` compared with `np.isclose`'s default `atol` of
1e-8, which is larger than several of the constants they check. Every constant
below 1e-8 therefore compared equal to every other one, and to zero. Two
expectations had already drifted behind that gap: `hbar` held `h_planck`'s
value, copy-pasted from the line above, and `hbarc` was off by ten orders of
magnitude. The library's own values were correct — only the tests were wrong,
and `test_constants.py`'s ROOT-vs-NumExpr cross-check was passing vacuously for
six constants. Now compared relatively with no absolute floor. The bound is
1e-8 rather than something tighter because ROOT hardcodes CODATA's rounded
`1.054571817e-34` while hepunits divides the exact `h` by 2π — a real 6e-10
disagreement, and the only one in the file; everything else is bit-exact.

**AST nodes are no longer comparable or hashable** (breaking, though the
methods were only ever the dataclass-generated defaults). The review flagged
that `==` and `hash()` recursed — both compare the field tuple, and a field
holding a child node makes that a recursive descent, so a tree that serialized
fine raised `RecursionError` at ~1,200 levels. Making them iterative fixed the
symptom but left the real problem: structural equality is not the question
anyone is asking. It calls `a + b` and `b + a` different expressions, along
with `x * 1` and `x`, `(a + b) + c` and `a + (b + c)`, and any constant spelled
differently from the one parsed. Answering those properly is computer algebra,
well outside what a syntax translator can promise, so the package no longer
implies an answer: `__eq__` raises `TypeError` naming the alternative, and
`__hash__` is `None` so nodes are honestly not `Hashable`.

Compare serializations instead — `str(node)` for the canonical form, or a
`to_*` rendering. Those are deterministic and fully parenthesized, so equal
strings mean identically shaped trees, which is what most of the suite already
relied on.

**Dotted branch names produced unusable NumExpr.** `branch.leaf` is one ROOT
name, not an attribute access, and NumExpr rejects any expression containing a
dot. These were emitted unchanged. They are now hex-encoded the way uproot
encodes C++ class names — `branch.leaf` → `branch_2e_leaf` — using uproot's
pattern verbatim, so the two packages spell a given name identically and
uproot's own decoder inverts it. Encoding is deliberately one-way: `from_numexpr`
cannot distinguish an encoded `branch.leaf` from a branch genuinely named
`branch_2e_leaf`, and silently renaming the latter would be worse than not
restoring the former. Note that `variables` still reports ROOT's spelling, so
the docs now say it is the *encoded* name that must be supplied at evaluation.

**`:` was accepted below the top level.** It is never parenthesized — that is
the point, since it separates outputs rather than combining values — so a
nested one could not be written back out: `(a:b)+c` serialized as `a : b + c`
and re-parsed as `a:(b+c)`, silently changing which expressions a `TTree::Draw`
would produce. ROOT does not accept a nested one either, so it is now
restricted to the top of the grammar, with a `ParseError` suggestion that keys
off a lone colon so `TMath::Sqrt` does not trigger it.

**`complex(a, b)` rendered as `np.complex128(a, b)`**, which is a scalar type
constructor rather than the element-wise counterpart: it raises `TypeError` on
array input, which is what these expressions are almost always evaluated
against. NumPy's element-wise form is `a + 1j*b`, an expression rather than a
name, so the mapping is dropped and the missing entry raises — exactly as
`contains` already does for the same reason.

**Overflowing literals emitted a bare `inf`**, which no target accepts.
`1e999` is now read as the canonical `inf` constant, which already knows
`TMath::Infinity()` for ROOT, `float('inf')` for Python, and that NumExpr has
no spelling at all. Finite literals are untouched.

## Release safety

`deploy` depended only on `dist`, so publishing required nothing more than that
a wheel could be built — a release whose tests had failed would still reach
PyPI. `unittests` is now callable and CD invokes it, making the whole matrix a
prerequisite. It is skipped outside a release, since that workflow already runs
on every push and PR. Only `CODECOV_TOKEN` is passed rather than inheriting
every secret.

Added a smoke test that installs the built wheel and sdist and runs the suite
against them. Tests from a checkout exercise the source tree and cannot catch a
packaging mistake — the grammars are package data, and a wheel missing them
would pass every existing test and fail on import for users. This one runs on
PRs too.

## Housekeeping

- `__slots__ = ()` on the `AST` base. The node types were already `slots=True`,
  but a slotted class inheriting from an unslotted one still gets a `__dict__`,
  so the declaration was buying nothing.
- Coverage config moved from `.coveragerc` into `pyproject.toml`, with branch
  coverage and `fail_under = 100` — matching what codecov already required, so
  a gap fails locally instead of only after a push. Coverage reads `.coveragerc`
  *in preference to* `pyproject.toml`, so with both present the latter is
  silently ignored; one file now. Verified the suite reaches 100% without ROOT,
  so every job in the matrix can meet it.
- `nox -s build` now clears `dist/`, where `python -m build` actually writes,
  instead of `build/`, which hatchling never creates.
- `nox -s pylint` passes (10.00/10); it had been failing on `main`, so `nox`
  itself was red. The one real fix is naming `data`/`children` in the
  `lark.Tree` patterns rather than matching positionally, since `__match_args__`
  is a hand-written tuple on a non-dataclass. The rest are narrow suppressions
  with reasons.
- Fixed a latent `assume` in the invalid-character fuzz test, which allowlisted
  only two whitespace characters though the grammar ignores all of them.

## Deliberately not addressed

- **ROOT `&&` vs NumExpr `&` on non-boolean operands.** Real, but the binding
  difference is already documented, and NumExpr raises `NotImplementedError` on
  integer arrays rather than answering wrongly. The suggested fix — distinct
  canonical nodes — would fight the AST's central invariant that all three
  spellings collapse to one node.
- **Serialization cost on skewed trees.** Measured ~n^1.5, not quadratic;
  32,000 terms serialize in 172 ms.
- **Parsers accept the other dialect's functions.** Real laxness, but errors are
  deferred rather than lost — `from_root("where(a,b,c)").to_root()` does raise.
- **Widening the Python matrix.** Judged not worth the CI time.
